### PR TITLE
feat: add discriminator support for Jackson polymorphism (v3.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,20 @@
 # Change Log
+
+## [3.0.0]
+### Feature
+- **Discriminator support** — добавлена генерация `@JsonTypeInfo` и `@JsonSubTypes` для полиморфной десериализации в Jackson
+  - `@JsonTypeInfo` на базовом классе с указанием поля-дискриминатора
+  - `@JsonSubTypes` со списком всех подтипов
+  - Пример использования в `discriminator.yaml`
+
+### Changes
+- **Version bump** — версия поднята до 3.0.0 в связи с новым функционалом
+- **Test coverage** — добавлен интеграционный тест `discriminator()`
+- **Documentation** — обновлён README.md с секциями 6.1 и 10.1
+
+### Future (see JSON_TYPE_ID_PLAN.md)
+- `@JsonTypeId` на поле дискриминатора в подтипах
+
 ## [2.0.1]
 ### Fix
 - Исправлен баг с @NoArgsConstructor когда в build.gradle он отключен, но аннотация все равно добавляется к классу.

--- a/JSON_TYPE_ID_PLAN.md
+++ b/JSON_TYPE_ID_PLAN.md
@@ -1,0 +1,71 @@
+# JsonTypeId Implementation Plan
+
+## Goal
+Add `@JsonTypeId` annotation to discriminator field in subtypes for explicit polymorphic typing.
+
+## Current State
+- ✅ Base schema (`Pet`) has `@JsonTypeInfo` + `@JsonSubTypes`
+- ❌ Subtypes (`Cat`, `Dog`) do NOT have `@JsonTypeId` on discriminator field
+
+## Desired Result
+```java
+// Cat.java
+@JsonTypeId
+private String petType;  // ← discriminator field marked with @JsonTypeId
+```
+
+## Implementation Steps
+
+### Step 1: Pass discriminator name to subtypes
+**File:** `SchemaMapper.java`
+
+Find the discriminator field name from base schema and store in subtypes.
+
+```java
+// In processDiscriminators():
+// For each subtype, find the discriminator field name from base schema
+String discriminatorField = baseDiscriminator.get(baseName);  // e.g., "petType"
+subtypeSchema.setDiscriminatorField(discriminatorField);
+```
+
+### Step 2: Add discriminator field to Schema
+**File:** `Schema.java`
+
+```java
+private String discriminatorField;
+
+public String getDiscriminatorField() { return discriminatorField; }
+public void setDiscriminatorField(String field) { this.discriminatorField = field; }
+```
+
+### Step 3: Generate @JsonTypeId on field
+**File:** `Schema.java` / `VariableProperties.java`
+
+When generating fields, check if this field is the discriminator:
+
+```java
+// In field generation logic
+if (schema.getDiscriminatorField() != null && 
+    fieldName.equals(schema.getDiscriminatorField())) {
+    fieldAnnotations.append("@JsonTypeId").append(lineSeparator());
+    requiredImports.add("com.fasterxml.jackson.annotation.JsonTypeId;");
+}
+```
+
+### Step 4: Add Dictionary constants
+**File:** `Dictionary.java`
+
+```java
+public static final String JSON_TYPE_ID_ANNOTATION = "@JsonTypeId";
+public static final String JSON_TYPE_ID_IMPORT = "com.fasterxml.jackson.annotation.JsonTypeId;";
+```
+
+## Notes
+
+- `@JsonTypeId` is **optional** — Jackson works without it
+- Use case: explicit typing when field name differs from type name
+- Can be added later when needed
+
+## References
+- Jackson Docs: `@JsonTypeId`
+- Test file: `discriminator.yaml`

--- a/README.md
+++ b/README.md
@@ -152,6 +152,57 @@ public class PolymorphStatusOnlyStatusWithCode {
 
 ---
 
+### 6.1 Discriminator (`discriminator` + `allOf`)
+**YAML** — для явной типизации при десериализации
+```yaml
+Pet:
+  type: object
+  discriminator: petType
+  properties:
+    name:
+      type: string
+    petType:
+      type: string
+
+Cat:
+  allOf:
+    - $ref: '#/components/schemas/Pet'
+  properties:
+    huntingSkill:
+      type: string
+
+Dog:
+  allOf:
+    - $ref: '#/components/schemas/Pet'
+  properties:
+    packSize:
+      type: integer
+```
+→ **Java**
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Cat.class, name = "Cat"),
+    @JsonSubTypes.Type(value = Dog.class, name = "Dog")
+})
+public class Pet {
+    private String name;
+    private String petType;
+}
+
+public class Cat extends Pet {
+    private String huntingSkill;
+}
+
+public class Dog extends Pet {
+    private Integer packSize;
+}
+```
+
+> ✅ Полиморфная десериализация работает автоматически: Jackson читает поле `petType` и создаёт нужный класс (`Cat` или `Dog`).
+
+---
+
 ### 7. Inheritance & Interfaces (complete cases)
 
 #### 7.1 Simple inheritance
@@ -218,6 +269,44 @@ MyDto:
 |--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | Marker       | <pre lang="yaml">Marker:<br>  type: object<br>  format: interface</pre>                                                                                                                                                                              | <pre lang="java">public interface Marker {}</pre>                                                                                 |
 | With methods | <pre lang="yaml">UserService:<br>  type: object<br>  format: interface<br>  imports:<br>    - com.my.dto.User<br>  methods:<br>    createUser:<br>      description: "Creates a new user"<br>      definition: "User createUser(String email)"</pre> | <pre lang="java">public interface UserService {<br>    /** Creates a new user */<br>    User createUser(String email);<br>}</pre> |
+
+---
+
+### 10.1 Discriminator (`discriminator` + `allOf`)
+
+| Attribute       | YAML                                                                                                                                                                                                 | → Java                                                                                               |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `discriminator` | <pre lang="yaml">Pet:<br>  type: object<br>  discriminator: type<br>  properties:<br>    name: string<br>    type: string</pre> | `@JsonTypeInfo`, `@JsonSubTypes` annotations |
+
+**Example:**
+```yaml
+Pet:
+  type: object
+  discriminator: petType
+  properties:
+    name:
+      type: string
+    petType:
+      type: string
+
+Cat:
+  allOf:
+    - $ref: '#/components/schemas/Pet'
+  properties:
+    huntingSkill:
+      type: string
+```
+
+→ **Java:**
+```java
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Cat.class, name = "Cat")
+})
+public class Pet { ... }
+```
+
+> ✅ Jackson автоматически десериализует в нужный класс по значению дискриминатора.
 
 ---
 
@@ -334,11 +423,13 @@ tasks.compileJava {
 
 | Feature                      | Status                 | Description                                      |
 |------------------------------|------------------------|--------------------------------------------------|
-| **Jackson annotations**      | ✅ In progress          | `@JsonProperty`, `@JsonFormat`, `@JsonInclude`   |
-| **AsyncAPI spec validation** | ✅ In progress          | Validate `$ref`, `type`, `format`, circular refs |
-| **Lombok extensions**        | ✅ In progress          | `@Builder`, `@Singular`, `@SuperBuilder`         |
-| **OpenAPI 3.1 support**      | 🚧 Planned for Q2 2026 | Only after AsyncAPI 3.0 stabilization            |
-| **Freemarker templates**     | 🚧 Planned             | For enterprise customizations                    |
+| **Discriminator**            | ✅ Done                 | `@JsonTypeInfo`, `@JsonSubTypes` for polymorphism |
+| **@JsonTypeId on fields**   | 📋 Future              | Add `@JsonTypeId` to discriminator field in subtypes |
+| **Jackson annotations**      | 🟡 Partial             | `@JsonProperty`, `@JsonInclude` done                |
+| **AsyncAPI spec validation** | 🚧 Planned              | Validate `$ref`, `type`, `format`, circular refs   |
+| **Lombok extensions**        | 🚧 Planned              | `@Builder`, `@Singular`, `@SuperBuilder`            |
+| **OpenAPI 3.1 support**     | 🚧 Planned for Q2 2026  | Only after AsyncAPI 3.0 stabilization            |
+| **Freemarker templates**      | 🚧 Planned              | For enterprise customizations                    |
 
 ---
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ java {
 
 group 'io.github.yojo-generator'
 //archivesBaseName = "generator"
-version '2.2.0'
+version '3.0.0'
 
 publishing {
     repositories {
@@ -150,6 +150,9 @@ dependencies {
     testImplementation 'org.projectlombok:lombok:1.18.30'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.assertj:assertj-core:3.27.7'
+
+    // Jackson for @JsonTypeInfo/@JsonSubTypes tests
+    testImplementation 'com.fasterxml.jackson.core:jackson-annotations:2.18.3'
 
     testImplementation 'jakarta.validation:jakarta.validation-api:3.1.1'
     testImplementation 'javax.validation:validation-api:2.0.1.Final'

--- a/src/main/java/ru/yojo/codegen/constants/Dictionary.java
+++ b/src/main/java/ru/yojo/codegen/constants/Dictionary.java
@@ -232,6 +232,10 @@ public final class Dictionary {
      * Custom attribute for multiple of validation
      */
     public static final String MULTIPLE_OF = "multipleOf";
+    /**
+     * YAML property name for discriminator
+     */
+    public static final String DISCRIMINATOR = "discriminator";
 
     /**
      * Lombok configuration keys (manual override section).
@@ -419,6 +423,26 @@ public final class Dictionary {
      * JsonPropertyDescription annotation template
      */
     public static final String JSON_PROPERTY_DESCRIPTION_ANNOTATION = "@JsonPropertyDescription()";
+    /**
+     * Jackson JsonTypeInfo annotation template
+     */
+    public static final String JSON_TYPE_INFO_ANNOTATION = "@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = \"%s\", visible = true)";
+    /**
+     * Jackson JsonSubTypes annotation template
+     */
+    public static final String JSON_SUB_TYPES_ANNOTATION = "@JsonSubTypes({%s})";
+    /**
+     * Jackson JsonSubTypes.Type annotation template
+     */
+    public static final String JSON_SUB_TYPE_ANNOTATION = "        @JsonSubTypes.Type(value = %s.class, name = \"%s\")";
+    /**
+     * Jackson @JsonTypeId annotation (for discriminator field in subtypes)
+     */
+    public static final String JSON_TYPE_ID_ANNOTATION = "@JsonTypeId";
+    /**
+     * Jackson @JsonTypeId import
+     */
+    public static final String JSON_TYPE_ID_IMPORT = "com.fasterxml.jackson.annotation.JsonTypeId;";
 
     /**
      * Lombok annotation string templates.
@@ -495,6 +519,15 @@ public final class Dictionary {
      * Import for Lombok EqualsAndHashCode
      */
     public static final String LOMBOK_EQUALS_AND_HASH_CODE_IMPORT = "lombok.EqualsAndHashCode;";
+
+    /**
+     * Jackson @JsonTypeInfo import
+     */
+    public static final String JSON_TYPE_INFO_IMPORT = "com.fasterxml.jackson.annotation.JsonTypeInfo;";
+    /**
+     * Jackson @JsonSubTypes import
+     */
+    public static final String JSON_SUB_TYPES_IMPORT = "com.fasterxml.jackson.annotation.JsonSubTypes;";
 
     /**
      * Canonical Java class simple names (used in field types, etc.).
@@ -742,6 +775,7 @@ public final class Dictionary {
      * Import for JsonPropertyDescription annotation
      */
     public static final String JSON_PROPERTY_DESCRIPTION_IMPORT = "com.fasterxml.jackson.annotation.JsonPropertyDescription;";
+
     /**
      * Import for URI class
      */

--- a/src/main/java/ru/yojo/codegen/domain/schema/Schema.java
+++ b/src/main/java/ru/yojo/codegen/domain/schema/Schema.java
@@ -4,8 +4,10 @@ import ru.yojo.codegen.domain.FillParameters;
 import ru.yojo.codegen.domain.VariableProperties;
 import ru.yojo.codegen.domain.lombok.LombokProperties;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -89,6 +91,39 @@ public class Schema {
      * Class-level annotations specified via x-class-annotation.
      */
     private Set<String> classAnnotations = new HashSet<>();
+
+    /**
+     * Discriminator field name for polymorphic serialization.
+     */
+    private String discriminator;
+
+    /**
+     * List of subtypes for @JsonSubTypes annotation.
+     */
+    private List<String> subtypes = new ArrayList<>();
+
+    /**
+     * Set of unique subtypes (deduplicated).
+     */
+    private Set<String> uniqueSubtypes = new HashSet<>();
+
+    /**
+     * Adds a subtype (deduplicates automatically).
+     */
+    public void addSubtype(String subtype) {
+        if (!uniqueSubtypes.contains(subtype)) {
+            uniqueSubtypes.add(subtype);
+            subtypes.add(subtype);
+        }
+    }
+
+    /**
+     * Clears all subtypes.
+     */
+    public void clearSubtypes() {
+        subtypes.clear();
+        uniqueSubtypes.clear();
+    }
 
     // ——— Getters & Setters ——— //
 
@@ -234,6 +269,34 @@ public class Schema {
      */
     public void setClassAnnotations(Set<String> classAnnotations) {
         this.classAnnotations = classAnnotations;
+    }
+
+    /**
+     * Returns the discriminator field name.
+     */
+    public String getDiscriminator() {
+        return discriminator;
+    }
+
+    /**
+     * Sets the discriminator field name.
+     */
+    public void setDiscriminator(String discriminator) {
+        this.discriminator = discriminator;
+    }
+
+    /**
+     * Returns list of subtypes.
+     */
+    public List<String> getSubtypes() {
+        return subtypes;
+    }
+
+    /**
+     * Sets list of subtypes.
+     */
+    public void setSubtypes(List<String> subtypes) {
+        this.subtypes = subtypes;
     }
 
     /**
@@ -418,6 +481,28 @@ public class Schema {
                     : annotation;
                 lombokAnnotationBuilder.append("@").append(simpleName).append(lineSeparator());
                 requiredImports.add(annotation.endsWith(";") ? annotation : annotation + ";");
+            }
+        }
+
+        // Add Jackson polymorphic annotations (discriminator)
+        if (discriminator != null && !discriminator.isEmpty()) {
+            requiredImports.add(JSON_TYPE_INFO_IMPORT);
+            requiredImports.add(JSON_SUB_TYPES_IMPORT);
+            lombokAnnotationBuilder.append(String.format(JSON_TYPE_INFO_ANNOTATION, discriminator)).append(lineSeparator());
+            
+            if (!subtypes.isEmpty()) {
+                StringBuilder subtypesBuilder = new StringBuilder();
+                subtypesBuilder.append("@JsonSubTypes({").append(lineSeparator());
+                for (int i = 0; i < subtypes.size(); i++) {
+                    subtypesBuilder.append(String.format("    @JsonSubTypes.Type(value = %s.class, name = \"%s\")", subtypes.get(i), subtypes.get(i)));
+                    if (i < subtypes.size() - 1) {
+                        subtypesBuilder.append(",").append(lineSeparator());
+                    } else {
+                        subtypesBuilder.append(lineSeparator());
+                    }
+                }
+                subtypesBuilder.append("})");
+                lombokAnnotationBuilder.append(subtypesBuilder).append(lineSeparator());
             }
         }
 

--- a/src/main/java/ru/yojo/codegen/mapper/SchemaMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/SchemaMapper.java
@@ -194,7 +194,78 @@ public class SchemaMapper extends AbstractMapper {
             });
         }
 
+        // Process discriminator-based polymorphism
+        processDiscriminators(schemaList, processContext.getSchemasMap());
+
         return schemaList;
+    }
+
+    /**
+     * Processes discriminator-based polymorphism.
+     * <p>
+     * Scans all schemas to find:
+     * <ul>
+     *   <li>Base schemas with {@code discriminator} field — marks them as polymorphic roots</li>
+     *   <li>Subtypes via {@code allOf} with {@code $ref} to base schema — adds them to subtypes list</li>
+     * </ul>
+     * <p>
+     * Result: base schema gets @JsonTypeInfo + @JsonSubTypes annotations.
+     */
+    private void processDiscriminators(List<Schema> schemaList, Map<String, Object> schemasMap) {
+        // Clear existing subtypes to avoid duplication
+        for (Schema schema : schemaList) {
+            schema.clearSubtypes();
+        }
+        
+        Map<String, String> baseDiscriminator = new HashMap<>();
+        Map<String, Schema> schemaByName = new HashMap<>();
+        
+// Find base schemas with discriminator
+        for (Schema schema : schemaList) {
+            String key = capitalize(schema.getSchemaName());
+            Map<String, Object> schemaMap = castObjectToMap(schemasMap.get(key));
+            if (schemaMap != null && schemaMap.containsKey(DISCRIMINATOR)) {
+                String disc = getStringValueIfExistOrElseNull(DISCRIMINATOR, schemaMap);
+                if (disc != null && !disc.isEmpty()) {
+                    baseDiscriminator.put(schema.getSchemaName(), disc);
+                    schema.setDiscriminator(disc);
+                    schemaByName.put(schema.getSchemaName(), schema);
+                }
+            }
+        }
+
+        // Find subtypes
+        for (Schema schema : schemaList) {
+            String schemaName = schema.getSchemaName();
+            if (baseDiscriminator.containsKey(schemaName)) continue;
+
+            String key = capitalize(schemaName);
+            Map<String, Object> schemaMap = castObjectToMap(schemasMap.get(key));
+            if (schemaMap == null || !schemaMap.containsKey(ALL_OF)) continue;
+
+            List<Object> allOfList = castObjectToListObjects(schemaMap.get(ALL_OF));
+            for (Object item : allOfList) {
+                Map<String, Object> itemMap = castObjectToMap(item);
+                if (itemMap == null) continue;
+                String ref = getStringValueIfExistOrElseNull(REFERENCE, itemMap);
+                if (ref == null) continue;
+                String baseName = refReplace(ref);
+                if (baseDiscriminator.containsKey(baseName)) {
+                    Schema baseSchema = schemaByName.get(baseName);
+                    if (baseSchema != null) {
+                        baseSchema.getSubtypes().add(schemaName);
+                    }
+                }
+            }
+}
+    }
+
+    /**
+     * Capitalize first letter.
+     */
+    private static String capitalize(String s) {
+        if (s == null || s.isEmpty()) return s;
+        return s.substring(0, 1).toUpperCase() + s.substring(1);
     }
 
     /**

--- a/src/test/java/ru/yojo/codegen/generator/ComprehensiveFeatureTest.java
+++ b/src/test/java/ru/yojo/codegen/generator/ComprehensiveFeatureTest.java
@@ -54,6 +54,22 @@ class ComprehensiveFeatureTest {
         }
     }
 
+
+    // Cleanup after discriminator test
+    @AfterEach
+    void cleanupAfterDiscriminator() throws IOException {
+        Path path = Paths.get(BASE_DIR);
+        if (Files.exists(path)) {
+            try (Stream<Path> walk = Files.walk(path)) {
+                walk.sorted((a, b) -> -a.compareTo(b))
+                        .forEach(p -> {
+                            try { Files.deleteIfExists(p); } catch (IOException ignore) {}
+                        });
+            }
+            Files.deleteIfExists(path);
+        }
+    }
+
     // ———————————————————————————————————————————————————————————————————————
     // ✅ 1. Основной кейс: generateTemplatesFromTrafficResponseMessage → List<Object>, а не Array
     // ———————————————————————————————————————————————————————————————————————
@@ -259,6 +275,33 @@ class ComprehensiveFeatureTest {
 
         // removeSchema — RequestDtoByRef does NOT generate RequestDtoSchema in messages/
         assertFalse(new File(BASE_DIR + "messages/RequestDtoSchema.java").exists());
+    }
+
+    // ———————————————————————————————————————————————————————————————————————
+    // ✅ Discriminator: @JsonTypeInfo + @JsonSubTypes for polymorphic schemas
+    // ———————————————————————————————————————————————————————————————————————
+
+    @Test
+    @Order(15)
+    void discriminator() throws IOException {
+        generate("discriminator.yaml", "", "example.testGenerate");
+
+        // Base schema should have @JsonTypeInfo and @JsonSubTypes
+        String pet = readFile("common/Pet.java");
+        assertThat(pet)
+                .contains("@JsonTypeInfo(use = JsonTypeInfo.Id.NAME")
+                .contains("@JsonSubTypes({")
+                .contains("@JsonSubTypes.Type(value = Cat.class")
+                .contains("@JsonSubTypes.Type(value = Dog.class")
+                .contains("import com.fasterxml.jackson.annotation.JsonTypeInfo;")
+                .contains("import com.fasterxml.jackson.annotation.JsonSubTypes;");
+
+        // Subtypes should NOT have @JsonTypeInfo
+        String cat = readFile("common/Cat.java");
+        assertThat(cat).doesNotContain("@JsonTypeInfo");
+
+        String dog = readFile("common/Dog.java");
+        assertThat(dog).doesNotContain("@JsonTypeInfo");
     }
 
     // ———————————————————————————————————————————————————————————————————————
@@ -621,6 +664,7 @@ class ComprehensiveFeatureTest {
         // Generate ALL specs
         generateWithLombok("spec-from-issue.yaml", "specFromIssue", "example.testGenerate.specFromIssue");
         generateWithLombok("test.yaml", "", "example.testGenerate");
+        generateWithLombok("discriminator.yaml", "", "example.testGenerate");
         generateWithLombok("async-api-official-v3.0.yaml", "asyncapi", "example.testGenerate.asyncapi");
         generateWithLombok("gitter-streaming-async-api-v3.0.yaml", "gitter", "example.testGenerate.gitter");
         generateWithLombok("slack-real-time-async-api-v3.0.yaml", "slack", "example.testGenerate.slack");

--- a/src/test/resources/example/contract/discriminator.yaml
+++ b/src/test/resources/example/contract/discriminator.yaml
@@ -1,0 +1,45 @@
+asyncapi: 2.0.0
+info:
+  title: Discriminator Example
+  version: 1.0.0
+channels:
+  pet:
+    subscribe:
+      message:
+        payload:
+          oneOf:
+            - $ref: '#/components/schemas/Cat'
+            - $ref: '#/components/schemas/Dog'
+components:
+  schemas:
+    Pet:
+      type: object
+      discriminator: petType
+      lombok:
+        accessors:
+          chain: true
+        allArgsConstructor: true
+        noArgsConstructor: true
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+    Cat:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          lombok:
+            allArgsConstructor: true
+          properties:
+            huntingSkill:
+              type: string
+    Dog:
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          lombok:
+            allArgsConstructor: true
+          properties:
+            packSize:
+              type: integer


### PR DESCRIPTION
- Add @JsonTypeInfo and @JsonSubTypes generation for polymorphic schemas
- Base schema gets discriminator field + list of subtypes
- Example: discriminator.yaml test file
- Integration test: discriminator()
- Update README with sections 6.1 and 10.1
- Add JSON_TYPE_ID_PLAN.md for future implementation
- Version bump to 3.0.0

Issues: https://github.com/yojo-generator/generator/issues/53 and https://github.com/yojo-generator/generator/issues/39
