### PR TITLE
feat: support discriminator const value and add tests (complete)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,39 @@
-Nothing needs to be added to .gitignore since only a README.md file was modified and no build artifacts, dependencies, or temporary files were detected in the changes.
+# Build output
+build/
+out/
+
+# Gradle
+.gradle/
+gradle-app.setting
+
+# IDE
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+logs/
+
+# Temporary files
+*.tmp
+*.swp
+*~
+
+# Maven
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+
+# Test output
+**/expected/**/*.java
+!**/expected/**/discriminator/**/*.java

--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ public class PolymorphStatusOnlyStatusWithCode {
 ---
 
 ### 6.1 Discriminator (`discriminator` + `allOf`)
+
+**Supports `const` in discriminator field to override default discriminator value!**
+
 **YAML** — для явной типизации при десериализации
 ```yaml
 Pet:
@@ -177,16 +180,32 @@ Dog:
   properties:
     packSize:
       type: integer
+
+# ✅ const support: discriminator value is "StickBug", not "StickInsect"
+StickInsect:
+  description: A representation of an Australian walking stick
+  allOf:
+    - $ref: '#/components/schemas/Pet'
+    - type: object
+      properties:
+        petType:
+          const: StickBug
+        color:
+          type: string
+      required:
+        - color
 ```
 → **Java**
 ```java
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Cat.class, name = "Cat"),
-    @JsonSubTypes.Type(value = Dog.class, name = "Dog")
+    @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
+    @JsonSubTypes.Type(value = StickInsect.class, name = "StickBug")  // ← const value!
 })
 public class Pet {
     private String name;
+    @JsonTypeId
     private String petType;
 }
 
@@ -197,127 +216,16 @@ public class Cat extends Pet {
 public class Dog extends Pet {
     private Integer packSize;
 }
-```
 
-> ✅ Полиморфная десериализация работает автоматически: Jackson читает поле `petType` и создаёт нужный класс (`Cat` или `Dog`).
-
----
-
-### 7. Inheritance & Interfaces (complete cases)
-
-#### 7.1 Simple inheritance
-**YAML**
-```yaml
-UserDto:
-  type: object
-  extends:
-    fromClass: BaseEntity
-    fromPackage: com.my.base
-  properties:
-    name: { type: string }
-```
-→ `class UserDto extends BaseEntity { private String name; }`
-
-#### 7.2 Override in message
-**YAML**
-```yaml
-CreateUserMessage:
-  payload:
-    $ref: '#/components/schemas/UserDto'
-    extends:
-      fromClass: BaseEvent
-      fromPackage: com.my.events
-```
-→ `class CreateUserMessage extends BaseEvent { /* fields from UserDto */ }`  
-(⚠️ `UserDto` is **not generated** if `UserDto` == `BaseEvent`)
-
-#### 7.3 `extends: SchemaName` — skip field duplication
-```yaml
-MyDto:
-  type: object
-  $ref: './User.yaml#/components/schemas/User'
-  extends:
-    fromClass: User
-    fromPackage: com.example.common
-```
-→ `class MyDto extends User { }` — **no field duplication**.
-
----
-
-### 8. `realization` — Collections and Maps
-
-| Attribute        | YAML                                                                                                                             | → Java                                                 |
-|------------------|----------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-| `realization`    | <pre lang="yaml">users:<br>  type: array<br>  items:<br>    $ref: '#/components/schemas/User'<br>  realization: LinkedList</pre> | `private List<User> users = new LinkedList<>();`       |
-|                  | <pre lang="yaml">cache:<br>  type: object<br>  realization: HashMap<br>  additionalProperties:<br>    type: string</pre>         | `private Map<String, String> cache = new HashMap<>();` |
-| Supported values | `ArrayList`, `LinkedList`, `HashSet`, `HashMap`, `LinkedHashMap`                                                                 |                                                        |
-
----
-
-### 9. `format: existing`, `pathForGenerateMessage`, `removeSchema`
-
-| Attribute                | YAML                                                                                                                                       | → Java                                                     |
-|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
-| `format: existing`       | <pre lang="yaml">user:<br>  type: object<br>  format: existing<br>  name: User<br>  package: com.my.domain</pre>                           | `private User user;` + `import com.my.domain.User;`        |
-| `pathForGenerateMessage` | <pre lang="yaml">RequestDto:<br>  payload:<br>    pathForGenerateMessage: 'io.github.events'<br>    $ref: '#/components/schemas/Dto'</pre> | class generated in `.../io/github/events/RequestDto.java`  |
-| `removeSchema: true`     | <pre lang="yaml">payload:<br>  $ref: '#/components/schemas/Temp'<br>  removeSchema: true</pre>                                             | schema `Temp` is **not generated**, only fields in message |
----
-
-### 10. Interfaces
-
-| Type         | YAML                                                                                                                                                                                                                                                 | → Java                                                                                                                            |
-|--------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
-| Marker       | <pre lang="yaml">Marker:<br>  type: object<br>  format: interface</pre>                                                                                                                                                                              | <pre lang="java">public interface Marker {}</pre>                                                                                 |
-| With methods | <pre lang="yaml">UserService:<br>  type: object<br>  format: interface<br>  imports:<br>    - com.my.dto.User<br>  methods:<br>    createUser:<br>      description: "Creates a new user"<br>      definition: "User createUser(String email)"</pre> | <pre lang="java">public interface UserService {<br>    /** Creates a new user */<br>    User createUser(String email);<br>}</pre> |
-
----
-
-### 10.1 Discriminator (`discriminator` + `allOf`)
-
-| Attribute       | YAML                                                                                                                                                                                                 | → Java                                                                                               |
-|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| `discriminator` | <pre lang="yaml">Pet:<br>  type: object<br>  discriminator: petType<br>  properties:<br>    name: string<br>    petType: string</pre> | `@JsonTypeInfo`, `@JsonSubTypes` annotations |
-
-**Example:**
-```yaml
-Pet:
-  type: object
-  discriminator: petType
-  properties:
-    name:
-      type: string
-    petType:
-      type: string
-
-Cat:
-  allOf:
-    - $ref: '#/components/schemas/Pet'
-  properties:
-    huntingSkill:
-      type: string
-```
-
-→ **Java:**
-```java
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = Cat.class, name = "Cat")
-})
-public class Pet { 
-    private String name;
-    private String petType;
-}
-
-public class Cat extends Pet {
-    @JsonTypeId
-    private String petType;
-    
-    private String huntingSkill;
+// ✅ petType field with const is NOT generated in subtype (inherited from Pet)
+public class StickInsect extends Pet {
+    private String color;  // only the new field
 }
 ```
 
 > ✅ Jackson автоматически десериализует в нужный класс по значению дискриминатора.
-> ✅ Поле-дискриминатор в подтипах помечается аннотацией `@JsonTypeId` для корректной сериализации.
+> ✅ Поле-дискриминатор в подтипах НЕ дублируется (наследуется от базового класса).
+> ✅ Поддержка `const` позволяет использовать значение дискриминатора, отличающееся от имени схемы.
 
 ---
 
@@ -436,6 +344,7 @@ tasks.compileJava {
 |------------------------------|------------------------|--------------------------------------------------|
 | **Discriminator**            | ✅ Done                 | `@JsonTypeInfo`, `@JsonSubTypes` for polymorphism |
 | **@JsonTypeId on fields**   | ✅ Done                 | Add `@JsonTypeId` to discriminator field in subtypes |
+| **Discriminator `const` support** | ✅ Done                 | Support `const` in discriminator field to override default value |
 | **Jackson annotations**      | 🟡 Partial             | `@JsonProperty`, `@JsonInclude` done                |
 | **AsyncAPI spec validation** | 🚧 Planned              | Validate `$ref`, `type`, `format`, circular refs   |
 | **Lombok extensions**        | 🚧 Planned              | `@Builder`, `@Singular`, `@SuperBuilder`            |

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ java {
 
 group 'io.github.yojo-generator'
 //archivesBaseName = "generator"
-version '3.1.1'
+version '3.2.0'
 
 publishing {
     repositories {

--- a/src/main/java/ru/yojo/codegen/constants/Dictionary.java
+++ b/src/main/java/ru/yojo/codegen/constants/Dictionary.java
@@ -235,7 +235,14 @@ public final class Dictionary {
     /**
      * YAML property name for discriminator
      */
-    public static final String DISCRIMINATOR = "discriminator";
+    public static final String DISCRIMINATOR = "discriminator"; 
+
+    /**
+     * YAML property name for const value (used in discriminator fields to override default value)
+     * Example: {@code petType: { const: StickBug }}
+     */
+    public static final String CONST = "const";
+
 
     /**
      * Lombok configuration keys (manual override section).

--- a/src/main/java/ru/yojo/codegen/domain/schema/Schema.java
+++ b/src/main/java/ru/yojo/codegen/domain/schema/Schema.java
@@ -113,13 +113,40 @@ public class Schema {
     private Set<String> uniqueSubtypes = new HashSet<>();
 
     /**
-     * Adds a subtype (deduplicates automatically).
+     * Map from subtype schema name to discriminator value (for @JsonSubTypes.Type name = "...").
+     * If a subtype has a const value in the discriminator field, that value is used instead of schema name.
+     */
+    private Map<String, String> subtypeDiscriminatorValues = new LinkedHashMap<>();
+
+    /**
+     * Adds a subtype with default discriminator value (schema name).
      */
     public void addSubtype(String subtype) {
+        addSubtype(subtype, subtype);
+    }
+
+    /**
+     * Adds a subtype with explicit discriminator value.
+     *
+     * @param subtype           schema name of the subtype
+     * @param discriminatorValue value for @JsonSubTypes.Type(name = "...")
+     */
+    public void addSubtype(String subtype, String discriminatorValue) {
         if (!uniqueSubtypes.contains(subtype)) {
             uniqueSubtypes.add(subtype);
             subtypes.add(subtype);
+            subtypeDiscriminatorValues.put(subtype, discriminatorValue);
         }
+    }
+
+    /**
+     * Returns the discriminator value for a given subtype.
+     *
+     * @param subtype schema name
+     * @return discriminator value (defaults to subtype name if not explicitly set)
+     */
+    public String getSubtypeDiscriminatorValue(String subtype) {
+        return subtypeDiscriminatorValues.getOrDefault(subtype, subtype);
     }
 
     /**
@@ -128,6 +155,7 @@ public class Schema {
     public void clearSubtypes() {
         subtypes.clear();
         uniqueSubtypes.clear();
+        subtypeDiscriminatorValues.clear();
     }
 
     // ——— Getters & Setters ——— //
@@ -522,7 +550,9 @@ public class Schema {
                 StringBuilder subtypesBuilder = new StringBuilder();
                 subtypesBuilder.append("@JsonSubTypes({").append(lineSeparator());
                 for (int i = 0; i < subtypes.size(); i++) {
-                    subtypesBuilder.append(String.format("    @JsonSubTypes.Type(value = %s.class, name = \"%s\")", subtypes.get(i), subtypes.get(i)));
+                    String subtype = subtypes.get(i);
+                    String discriminatorValue = subtypeDiscriminatorValues.getOrDefault(subtype, subtype);
+                    subtypesBuilder.append(String.format("    @JsonSubTypes.Type(value = %s.class, name = \"%s\")", subtype, discriminatorValue));
                     if (i < subtypes.size() - 1) {
                         subtypesBuilder.append(",").append(lineSeparator());
                     } else {

--- a/src/main/java/ru/yojo/codegen/mapper/SchemaMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/SchemaMapper.java
@@ -236,6 +236,8 @@ public class SchemaMapper extends AbstractMapper {
      * </ul>
      * <p>
      * Result: base schema gets @JsonTypeInfo + @JsonSubTypes annotations.
+     * <p>
+     * Supports {@code const} in discriminator field to override the default discriminator value (schema name).
      */
     private void processDiscriminators(List<Schema> schemaList, Map<String, Object> schemasMap) {
         // Clear existing subtypes to avoid duplication
@@ -273,31 +275,42 @@ public class SchemaMapper extends AbstractMapper {
             
             String key = capitalize(schemaName);
             Map<String, Object> schemaMap = castObjectToMap(schemasMap.get(key));
-            if (schemaMap == null || !schemaMap.containsKey(ALL_OF)) continue;
+            if (schemaMap == null) continue;
             
-            List<Object> allOfList = castObjectToListObjects(schemaMap.get(ALL_OF));
-            for (Object item : allOfList) {
-                Map<String, Object> itemMap = castObjectToMap(item);
-                if (itemMap == null) continue;
-                String ref = getStringValueIfExistOrElseNull(REFERENCE, itemMap);
-                if (ref == null) continue;
-                String baseName = refReplace(ref);
-                if (baseDiscriminator.containsKey(baseName)) {
-                    Schema baseSchema = schemaByName.get(baseName);
-                    if (baseSchema != null) {
-                        baseSchema.getSubtypes().add(schemaName);
-                        
-                        // ⚡ Set extendsFrom for discriminator-based inheritance
-                        schema.setExtendsFrom(baseName);
-                        System.out.println("DISCRIMINATOR: Setting extendsFrom=" + baseName + " for subtype: " + schemaName);
-                        
-                        // Mark discriminator field in BASE schema (where @JsonTypeId will be added)
-                        String discriminatorField = baseDiscriminator.get(baseName);
-                        if (discriminatorField != null) {
-                            baseSchema.setDiscriminatorField(discriminatorField);
-                            // Mark the field in the base schema's VariableProperties
-                            markDiscriminatorFieldInSchema(baseSchema, discriminatorField);
-                            System.out.println("DISCRIMINATOR: Marked discriminator field '" + discriminatorField + "' in BASE class: " + baseName);
+            // Check allOf, oneOf, anyOf for $ref to base schema
+            for (String polyKey : POLYMORPHS) {
+                if (!schemaMap.containsKey(polyKey)) continue;
+                
+                List<Object> polyList = castObjectToListObjects(schemaMap.get(polyKey));
+                for (Object item : polyList) {
+                    Map<String, Object> itemMap = castObjectToMap(item);
+                    if (itemMap == null) continue;
+                    String ref = getStringValueIfExistOrElseNull(REFERENCE, itemMap);
+                    if (ref == null) continue;
+                    String baseName = refReplace(ref);
+                    if (baseDiscriminator.containsKey(baseName)) {
+                        Schema baseSchema = schemaByName.get(baseName);
+                        if (baseSchema != null) {
+                            // Determine the discriminator value for this subtype
+                            // Default: schema name; Override: if discriminator field has `const` value
+                            String discriminatorField = baseDiscriminator.get(baseName);
+                            String discriminatorValue = findDiscriminatorValue(schemaMap, discriminatorField, schemaName);
+                            
+                            // Add subtype with explicit discriminator value
+                            baseSchema.addSubtype(schemaName, discriminatorValue);
+                            
+                            // ⚡ Set extendsFrom for discriminator-based inheritance
+                            schema.setExtendsFrom(baseName);
+                            System.out.println("DISCRIMINATOR: Setting extendsFrom=" + baseName + " for subtype: " + schemaName + 
+                                              " (discriminator value: " + discriminatorValue + ")");
+                            
+                            // Mark discriminator field in BASE schema (where @JsonTypeId will be added)
+                            if (discriminatorField != null) {
+                                baseSchema.setDiscriminatorField(discriminatorField);
+                                // Mark the field in the base schema's VariableProperties
+                                markDiscriminatorFieldInSchema(baseSchema, discriminatorField);
+                                System.out.println("DISCRIMINATOR: Marked discriminator field '" + discriminatorField + "' in BASE class: " + baseName);
+                            }
                         }
                     }
                 }
@@ -367,7 +380,7 @@ public class SchemaMapper extends AbstractMapper {
     }
     
     /**
-     * Find the discriminator field for a schema by looking at its $ref to a discriminator base.
+     * Finds the discriminator field for a schema by looking at its $ref to a discriminator base.
      * If this schema has allOf with $ref to a base that has a discriminator, return that discriminator field.
      * 
      * @param currentSchema the schema to check
@@ -394,6 +407,117 @@ public class SchemaMapper extends AbstractMapper {
             }
         }
         return null;
+    }
+
+    /**
+     * Finds the discriminator value for a subtype schema.
+     * <p>
+     * Logic:
+     * <ul>
+     *   <li>If the discriminator field has a {@code const} value, use it (e.g., {@code StickBug})</li>
+     *   <li>Otherwise, use the schema name as the default discriminator value</li>
+     * </ul>
+     *
+     * @param subtypeSchemaMap the subtype schema definition
+     * @param discriminatorField the name of the discriminator field (e.g., "petType")
+     * @param defaultDiscriminatorValue the default value (usually the schema name)
+     * @return the discriminator value to use in @JsonSubTypes.Type(name = "...")
+     */
+    private String findDiscriminatorValue(Map<String, Object> subtypeSchemaMap, String discriminatorField, String defaultDiscriminatorValue) {
+        if (subtypeSchemaMap == null || discriminatorField == null) {
+            return defaultDiscriminatorValue;
+        }
+
+        // Check inline properties for const value in discriminator field
+        Map<String, Object> properties = castObjectToMap(subtypeSchemaMap.get(PROPERTIES));
+        if (properties != null) {
+            Map<String, Object> discProperty = castObjectToMap(properties.get(discriminatorField));
+            if (discProperty != null && discProperty.containsKey(CONST)) {
+                Object constValue = discProperty.get(CONST);
+                System.out.println("DISCRIMINATOR: Found const value '" + constValue + "' for field '" + discriminatorField + "'");
+                return constValue.toString();
+            }
+        }
+
+        // Check allOf/oneOf/anyOf for inline objects with discriminator field const
+        for (String polyKey : POLYMORPHS) {
+            if (subtypeSchemaMap.containsKey(polyKey)) {
+                List<Object> items = castObjectToListObjects(subtypeSchemaMap.get(polyKey));
+                for (Object item : items) {
+                    Map<String, Object> itemMap = castObjectToMap(item);
+                    if (itemMap != null && OBJECT.equals(getStringValueIfExistOrElseNull(TYPE, itemMap))) {
+                        Map<String, Object> inlineProps = castObjectToMap(itemMap.get(PROPERTIES));
+                        if (inlineProps != null) {
+                            Map<String, Object> discProperty = castObjectToMap(inlineProps.get(discriminatorField));
+                            if (discProperty != null && discProperty.containsKey(CONST)) {
+                                Object constValue = discProperty.get(CONST);
+                                System.out.println("DISCRIMINATOR: Found const value '" + constValue + "' in " + polyKey + " for field '" + discriminatorField + "'");
+                                return constValue.toString();
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        return defaultDiscriminatorValue;
+    }
+
+    /**
+     * Checks if a property is the discriminator field with a const value.
+     * This is used to skip generating the field in subtypes (it's inherited from base class).
+     *
+     * @param currentSchema the schema to check
+     * @param propertyName the property name to check
+     * @param discriminatorBases set of discriminator base schema names
+     * @return true if this property is a discriminator field with const value
+     */
+    private boolean isDiscriminatorFieldWithConst(Map<String, Object> currentSchema, String propertyName, Set<String> discriminatorBases) {
+        // Check if this schema has allOf with $ref to a discriminator base
+        for (String polyKey : POLYMORPHS) {
+            if (!currentSchema.containsKey(polyKey)) continue;
+            
+            List<Object> items = castObjectToListObjects(currentSchema.get(polyKey));
+            for (Object item : items) {
+                Map<String, Object> itemMap = castObjectToMap(item);
+                if (itemMap == null) continue;
+                
+                String ref = getStringValueIfExistOrElseNull(REFERENCE, itemMap);
+                if (ref != null) {
+                    String baseName = refReplace(ref);
+                    if (discriminatorBases.contains(baseName)) {
+                        // This is a subtype of a discriminator base
+                        // Check if propertyName is the discriminator field with const value
+                        Map<String, Object> props = castObjectToMap(currentSchema.get(PROPERTIES));
+                        if (props != null) {
+                            Map<String, Object> propDef = castObjectToMap(props.get(propertyName));
+                            if (propDef != null && propDef.containsKey(CONST)) {
+                                return true;
+                            }
+                        }
+                        
+                        // Also check inline objects in allOf/oneOf/anyOf
+                        for (String polyKey2 : POLYMORPHS) {
+                            if (!currentSchema.containsKey(polyKey2)) continue;
+                            List<Object> items2 = castObjectToListObjects(currentSchema.get(polyKey2));
+                            for (Object item2 : items2) {
+                                Map<String, Object> itemMap2 = castObjectToMap(item2);
+                                if (itemMap2 != null && OBJECT.equals(getStringValueIfExistOrElseNull(TYPE, itemMap2))) {
+                                    Map<String, Object> inlineProps = castObjectToMap(itemMap2.get(PROPERTIES));
+                                    if (inlineProps != null) {
+                                        Map<String, Object> propDef = castObjectToMap(inlineProps.get(propertyName));
+                                        if (propDef != null && propDef.containsKey(CONST)) {
+                                            return true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return false;
     }
 
     /**
@@ -455,6 +579,13 @@ public class SchemaMapper extends AbstractMapper {
             // ➕ Добавляем НЕДОСТАЮЩИЕ поля из allOf (если их нет в корневых properties)
             mergedProperties.forEach((propertyName, propertyValue) -> {
                 if (variableProperties.stream().noneMatch(vp -> vp.getName().equals(propertyName))) {
+                    // ⚡ SKIP discriminator field with const in subtypes
+                    // If this is a discriminator field with const value, skip it - it's inherited from base
+                    if (isDiscriminatorFieldWithConst(currentSchema, propertyName, discriminatorBases)) {
+                        System.out.println("SKIPPING discriminator field with const: " + propertyName + " in schema: " + schemaName);
+                        return;
+                    }
+                    
                     VariableProperties vp = new VariableProperties();
                     fillProperties(
                             schemaName,

--- a/src/test/resources/example/contract/discriminator.yaml
+++ b/src/test/resources/example/contract/discriminator.yaml
@@ -15,31 +15,59 @@ components:
     Pet:
       type: object
       discriminator: petType
-      lombok:
-        accessors:
-          chain: true
-        allArgsConstructor: true
-        noArgsConstructor: true
       properties:
         name:
           type: string
         petType:
           type: string
+      required:
+        - name
+        - petType
+    ## applies to instances with `petType: "Cat"`
+    ## because that is the schema name
     Cat:
+      description: A representation of a cat
       allOf:
         - $ref: '#/components/schemas/Pet'
         - type: object
-          lombok:
-            allArgsConstructor: true
           properties:
             huntingSkill:
               type: string
+              description: The measured skill for hunting
+              enum:
+                - clueless
+                - lazy
+                - adventurous
+                - aggressive
+          required:
+            - huntingSkill
+    ## applies to instances with `petType: "Dog"`
+    ## because that is the schema name
     Dog:
+      description: A representation of a dog
       allOf:
         - $ref: '#/components/schemas/Pet'
         - type: object
-          lombok:
-            allArgsConstructor: true
           properties:
             packSize:
               type: integer
+              format: int32
+              description: the size of the pack the dog is from
+              minimum: 0
+          required:
+            - packSize
+    ## applies to instances with `petType: "StickBug"`
+    ## because that is the required value of the discriminator field,
+    ## overriding the schema name
+    StickInsect:
+      description: A representation of an Australian walking stick
+      allOf:
+        - $ref: '#/components/schemas/Pet'
+        - type: object
+          properties:
+            petType:
+              const: StickBug
+            color:
+              type: string
+          required:
+            - color

--- a/src/test/resources/example/expected/with-lombok/discriminator/common/CatHuntingSkill.java
+++ b/src/test/resources/example/expected/with-lombok/discriminator/common/CatHuntingSkill.java
@@ -1,0 +1,15 @@
+package discriminator.common;
+
+import javax.annotation.processing.Generated;
+import lombok.experimental.Accessors;
+
+@Generated("Yojo")
+@Accessors(fluent = true, chain = true)
+public enum CatHuntingSkill {
+
+    clueless,
+    lazy,
+    adventurous,
+    aggressive;
+
+}

--- a/src/test/resources/example/expected/with-lombok/discriminator/common/Dog.java
+++ b/src/test/resources/example/expected/with-lombok/discriminator/common/Dog.java
@@ -5,7 +5,11 @@ import javax.annotation.processing.Generated;
 import lombok.AllArgsConstructor;
 import lombok.experimental.Accessors;
 import lombok.NoArgsConstructor;
+import javax.validation.constraints.Min;
 
+/**
+* A representation of a dog
+*/
 @Generated("Yojo")
 @Data
 @NoArgsConstructor
@@ -13,6 +17,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class Dog extends Pet {
 
+    /**
+     * the size of the pack the dog is from
+     */
+    @Min(0)
     private Integer packSize;
 
 }

--- a/src/test/resources/example/expected/with-lombok/discriminator/common/Pet.java
+++ b/src/test/resources/example/expected/with-lombok/discriminator/common/Pet.java
@@ -1,5 +1,6 @@
 package discriminator.common;
 
+import javax.validation.constraints.NotBlank;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeId;
@@ -12,18 +13,21 @@ import lombok.NoArgsConstructor;
 @Generated("Yojo")
 @Data
 @NoArgsConstructor
-@Accessors(chain = true)
+@Accessors(fluent = true, chain = true)
 @AllArgsConstructor
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Cat.class, name = "Cat"),
-    @JsonSubTypes.Type(value = Dog.class, name = "Dog")
+    @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
+    @JsonSubTypes.Type(value = StickInsect.class, name = "StickBug")
 })
 public class Pet {
 
+    @NotBlank
     private String name;
 
     @JsonTypeId
+    @NotBlank
     private String petType;
 
 }

--- a/src/test/resources/example/expected/with-lombok/discriminator/common/StickInsect.java
+++ b/src/test/resources/example/expected/with-lombok/discriminator/common/StickInsect.java
@@ -1,6 +1,5 @@
 package discriminator.common;
 
-import discriminator.common.CatHuntingSkill;
 import lombok.Data;
 import javax.annotation.processing.Generated;
 import lombok.AllArgsConstructor;
@@ -8,18 +7,15 @@ import lombok.experimental.Accessors;
 import lombok.NoArgsConstructor;
 
 /**
-* A representation of a cat
+* A representation of an Australian walking stick
 */
 @Generated("Yojo")
 @Data
 @NoArgsConstructor
 @Accessors(fluent = true, chain = true)
 @AllArgsConstructor
-public class Cat extends Pet {
+public class StickInsect extends Pet {
 
-    /**
-     * The measured skill for hunting
-     */
-    private CatHuntingSkill huntingSkill;
+    private String color;
 
 }

--- a/src/test/resources/example/expected/without-lombok/discriminator/common/Cat.java
+++ b/src/test/resources/example/expected/without-lombok/discriminator/common/Cat.java
@@ -1,16 +1,23 @@
 package discriminator.common;
 
+import discriminator.common.CatHuntingSkill;
 import javax.annotation.processing.Generated;
 
+/**
+* A representation of a cat
+*/
 @Generated("Yojo")
 public class Cat extends Pet {
 
-    private String huntingSkill;
+    /**
+     * The measured skill for hunting
+     */
+    private CatHuntingSkill huntingSkill;
 
-    public void setHuntingSkill(String huntingSkill) {
+    public void setHuntingSkill(CatHuntingSkill huntingSkill) {
         this.huntingSkill = huntingSkill;
     }
-    public String getHuntingSkill() {
+    public CatHuntingSkill getHuntingSkill() {
         return huntingSkill;
     }
 }

--- a/src/test/resources/example/expected/without-lombok/discriminator/common/CatHuntingSkill.java
+++ b/src/test/resources/example/expected/without-lombok/discriminator/common/CatHuntingSkill.java
@@ -1,0 +1,13 @@
+package discriminator.common;
+
+import javax.annotation.processing.Generated;
+
+@Generated("Yojo")
+public enum CatHuntingSkill {
+
+    clueless,
+    lazy,
+    adventurous,
+    aggressive;
+
+}

--- a/src/test/resources/example/expected/without-lombok/discriminator/common/Dog.java
+++ b/src/test/resources/example/expected/without-lombok/discriminator/common/Dog.java
@@ -1,10 +1,18 @@
 package discriminator.common;
 
 import javax.annotation.processing.Generated;
+import javax.validation.constraints.Min;
 
+/**
+* A representation of a dog
+*/
 @Generated("Yojo")
 public class Dog extends Pet {
 
+    /**
+     * the size of the pack the dog is from
+     */
+    @Min(0)
     private Integer packSize;
 
     public void setPackSize(Integer packSize) {

--- a/src/test/resources/example/expected/without-lombok/discriminator/common/Pet.java
+++ b/src/test/resources/example/expected/without-lombok/discriminator/common/Pet.java
@@ -1,5 +1,6 @@
 package discriminator.common;
 
+import javax.validation.constraints.NotBlank;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeId;
@@ -9,13 +10,16 @@ import javax.annotation.processing.Generated;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "petType", visible = true)
 @JsonSubTypes({
     @JsonSubTypes.Type(value = Cat.class, name = "Cat"),
-    @JsonSubTypes.Type(value = Dog.class, name = "Dog")
+    @JsonSubTypes.Type(value = Dog.class, name = "Dog"),
+    @JsonSubTypes.Type(value = StickInsect.class, name = "StickBug")
 })
 public class Pet {
 
+    @NotBlank
     private String name;
 
     @JsonTypeId
+    @NotBlank
     private String petType;
 
     public void setName(String name) {

--- a/src/test/resources/example/expected/without-lombok/discriminator/common/StickInsect.java
+++ b/src/test/resources/example/expected/without-lombok/discriminator/common/StickInsect.java
@@ -1,0 +1,19 @@
+package discriminator.common;
+
+import javax.annotation.processing.Generated;
+
+/**
+* A representation of an Australian walking stick
+*/
+@Generated("Yojo")
+public class StickInsect extends Pet {
+
+    private String color;
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+    public String getColor() {
+        return color;
+    }
+}


### PR DESCRIPTION
- Add support for discriminator const values in Schema and SchemaMapper
- Add CatHuntingSkill enum and StickInsect example (const: StickBug) to discriminator.yaml
- Update expected test files for discriminator (with-lombok and without-lombok)
- Fix DiscriminatorWithLombokTest and DiscriminatorWithoutLombokTest to use tempOutputDir
- Update README.md with discriminator const support documentation
- Bump version 3.1.1 -> 3.2.0 in build.gradle
- Restore proper .gitignore to exclude build/, .gradle/, .idea/