### PR TITLE
fix: use title attribute for enum/object class naming (Issue #17)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ java {
 
 group 'io.github.yojo-generator'
 //archivesBaseName = "generator"
-version '4.1.0'
+version '4.2.0'
 
 publishing {
     repositories {

--- a/src/main/java/ru/yojo/codegen/mapper/AbstractMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/AbstractMapper.java
@@ -389,7 +389,10 @@ public class AbstractMapper {
                                      Map<String, Object> innerSchemas) {
         LOG.debug("ENUMERATION FOUND: " + propertyName + " in " + schemaName);
         String enumClassName;
-        if (schemaName.equalsIgnoreCase(propertyName)) {
+        String title = getStringValueIfExistOrElseNull(TITLE, propertiesMap);
+        if (title != null && !title.trim().isEmpty()) {
+            enumClassName = capitalize(title);
+        } else if (schemaName.equalsIgnoreCase(propertyName)) {
             enumClassName = capitalize(propertyName);
         } else {
             enumClassName = capitalize(schemaName) + capitalize(propertyName);
@@ -426,7 +429,13 @@ public class AbstractMapper {
                                       Map<String, Object> propertiesMap,
                                       ProcessContext processContext,
                                       Map<String, Object> innerSchemas) {
-        String propName = capitalize(schemaName) + capitalize(propertyName);
+        String title = getStringValueIfExistOrElseNull(TITLE, propertiesMap);
+        String propName;
+        if (title != null && !title.trim().isEmpty()) {
+            propName = capitalize(title);
+        } else {
+            propName = capitalize(schemaName) + capitalize(propertyName);
+        }
         fillInnerSchema(variableProperties, propName, propertiesMap, processContext, innerSchemas);
     }
 

--- a/src/test/resources/example/contract/enum-values.yaml
+++ b/src/test/resources/example/contract/enum-values.yaml
@@ -37,6 +37,21 @@ components:
             STOPPED: "T"
           x-enumDefault: true
 
+        # 3. Enum with title — class name should use title, not derive from property name
+        error:
+          title: ErrorCode
+          type: string
+          enum:
+            - VALIDATION_ERROR
+            - WALLET_NOT_FOUND
+            - INTERNAL_ERROR
+            - RATE_LIMIT_EXCEEDED
+          x-enumValues:
+            VALIDATION_ERROR: "VALIDATION_ERROR"
+            WALLET_NOT_FOUND: "WALLET_NOT_FOUND"
+            INTERNAL_ERROR: "INTERNAL_ERROR"
+            RATE_LIMIT_EXCEEDED: "RATE_LIMIT_EXCEEDED"
+
       # 3. Top-level enum with x-enumValues
     OrderStatus:
       type: object

--- a/src/test/resources/example/expected/with-lombok/enumvalues/common/ErrorCode.java
+++ b/src/test/resources/example/expected/with-lombok/enumvalues/common/ErrorCode.java
@@ -1,0 +1,37 @@
+package enumvalues.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.processing.Generated;
+import lombok.experimental.Accessors;
+
+@Generated("Yojo")
+@Accessors(fluent = true, chain = true)
+public enum ErrorCode {
+    VALIDATION_ERROR("VALIDATION_ERROR"),
+    WALLET_NOT_FOUND("WALLET_NOT_FOUND"),
+    INTERNAL_ERROR("INTERNAL_ERROR"),
+    RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED");
+
+    private final String value;
+
+    ErrorCode(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ErrorCode fromValue(String value) {
+        for (ErrorCode v : ErrorCode.values()) {
+            if (v.value.equals(value)) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("Unknown enum value: " + value);
+    }
+
+}

--- a/src/test/resources/example/expected/with-lombok/enumvalues/common/Payload.java
+++ b/src/test/resources/example/expected/with-lombok/enumvalues/common/Payload.java
@@ -1,5 +1,6 @@
 package enumvalues.common;
 
+import enumvalues.common.ErrorCode;
 import enumvalues.common.PayloadStatus;
 import enumvalues.common.PayloadStatusWithDefault;
 import javax.annotation.processing.Generated;
@@ -19,4 +20,6 @@ public class Payload {
     private PayloadStatus status;
 
     private PayloadStatusWithDefault statusWithDefault;
+
+    private ErrorCode error;
 }

--- a/src/test/resources/example/expected/with-lombok/enumvalues/messages/TestMessage.java
+++ b/src/test/resources/example/expected/with-lombok/enumvalues/messages/TestMessage.java
@@ -1,5 +1,6 @@
 package enumvalues.messages;
 
+import enumvalues.common.ErrorCode;
 import enumvalues.common.PayloadStatus;
 import enumvalues.common.PayloadStatusWithDefault;
 import javax.annotation.processing.Generated;
@@ -19,4 +20,6 @@ public class TestMessage {
     private PayloadStatus status;
 
     private PayloadStatusWithDefault statusWithDefault;
+
+    private ErrorCode error;
 }

--- a/src/test/resources/example/expected/without-lombok/enumvalues/common/ErrorCode.java
+++ b/src/test/resources/example/expected/without-lombok/enumvalues/common/ErrorCode.java
@@ -1,0 +1,35 @@
+package enumvalues.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import javax.annotation.processing.Generated;
+
+@Generated("Yojo")
+public enum ErrorCode {
+    VALIDATION_ERROR("VALIDATION_ERROR"),
+    WALLET_NOT_FOUND("WALLET_NOT_FOUND"),
+    INTERNAL_ERROR("INTERNAL_ERROR"),
+    RATE_LIMIT_EXCEEDED("RATE_LIMIT_EXCEEDED");
+
+    private final String value;
+
+    ErrorCode(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static ErrorCode fromValue(String value) {
+        for (ErrorCode v : ErrorCode.values()) {
+            if (v.value.equals(value)) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException("Unknown enum value: " + value);
+    }
+
+}

--- a/src/test/resources/example/expected/without-lombok/enumvalues/common/Payload.java
+++ b/src/test/resources/example/expected/without-lombok/enumvalues/common/Payload.java
@@ -1,5 +1,6 @@
 package enumvalues.common;
 
+import enumvalues.common.ErrorCode;
 import enumvalues.common.PayloadStatus;
 import enumvalues.common.PayloadStatusWithDefault;
 import javax.annotation.processing.Generated;
@@ -11,6 +12,8 @@ public class Payload {
     private PayloadStatus status;
 
     private PayloadStatusWithDefault statusWithDefault;
+
+    private ErrorCode error;
     public void setStatus(PayloadStatus status) {
         this.status = status;
     }
@@ -22,5 +25,11 @@ public class Payload {
     }
     public PayloadStatusWithDefault getStatusWithDefault() {
         return statusWithDefault;
+    }
+    public void setError(ErrorCode error) {
+        this.error = error;
+    }
+    public ErrorCode getError() {
+        return error;
     }
 }

--- a/src/test/resources/example/expected/without-lombok/enumvalues/messages/TestMessage.java
+++ b/src/test/resources/example/expected/without-lombok/enumvalues/messages/TestMessage.java
@@ -1,5 +1,6 @@
 package enumvalues.messages;
 
+import enumvalues.common.ErrorCode;
 import enumvalues.common.PayloadStatus;
 import enumvalues.common.PayloadStatusWithDefault;
 import javax.annotation.processing.Generated;
@@ -11,6 +12,8 @@ public class TestMessage {
     private PayloadStatus status;
 
     private PayloadStatusWithDefault statusWithDefault;
+
+    private ErrorCode error;
     public void setStatus(PayloadStatus status) {
         this.status = status;
     }
@@ -22,5 +25,11 @@ public class TestMessage {
     }
     public PayloadStatusWithDefault getStatusWithDefault() {
         return statusWithDefault;
+    }
+    public void setError(ErrorCode error) {
+        this.error = error;
+    }
+    public ErrorCode getError() {
+        return error;
     }
 }


### PR DESCRIPTION
## Summary

- When a property has a \	itle\ attribute, use it as the class name instead of deriving from schema+property name
- Fix applies to both inner enums (\illEnumProperties\) and inner objects (\illObjectProperties\)
- Example: \error: { title: ErrorCode, type: string, enum: [...] }\ now generates \ErrorCode\ enum instead of \Error\ (derived from property name)

Closes #17