### PR TITLE
feat: deprecate legacy custom attributes in favour of x- prefixed var…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ java {
 
 group 'io.github.yojo-generator'
 //archivesBaseName = "generator"
-version '4.2.0'
+version '4.3.0'
 
 publishing {
     repositories {

--- a/src/main/java/ru/yojo/codegen/constants/Dictionary.java
+++ b/src/main/java/ru/yojo/codegen/constants/Dictionary.java
@@ -95,6 +95,168 @@ public final class Dictionary {
      * When {@code true}, generates {@code private final Type name;} instead of {@code private Type name;}.
      */
     public static final String X_FINAL = "x-final";
+
+    // ============================================================
+    // Extension attributes migrated to x- prefix (Groups 1-3)
+    // Old names are @Deprecated for backward compatibility
+    // ============================================================
+
+    /**
+     * Custom attribute for specifying collection implementation.
+     * @deprecated Use {@link #X_REALIZATION} instead.
+     */
+    @Deprecated
+    public static final String REALIZATION = "realization";
+    /** Custom attribute for specifying collection implementation (x- prefix). */
+    public static final String X_REALIZATION = "x-realization";
+
+    /**
+     * Custom attribute for validation groups.
+     * @deprecated Use {@link #X_VALIDATION_GROUPS} instead.
+     */
+    @Deprecated
+    public static final String VALIDATION_GROUPS = "validationGroups";
+    /** Custom attribute for validation groups (x- prefix). */
+    public static final String X_VALIDATION_GROUPS = "x-validation-groups";
+
+    /**
+     * Custom attribute for validation groups imports.
+     * @deprecated Use {@link #X_VALIDATION_GROUPS_IMPORTS} instead.
+     */
+    @Deprecated
+    public static final String VALIDATION_GROUPS_IMPORTS = "validationGroupsImports";
+    /** Custom attribute for validation groups imports (x- prefix). */
+    public static final String X_VALIDATION_GROUPS_IMPORTS = "x-validation-groups-imports";
+
+    /**
+     * Custom attribute for enabling validation by groups.
+     * @deprecated Use {@link #X_VALIDATE_BY_GROUPS} instead.
+     */
+    @Deprecated
+    public static final String VALIDATE_BY_GROUPS = "validateByGroups";
+    /** Custom attribute for enabling validation by groups (x- prefix). */
+    public static final String X_VALIDATE_BY_GROUPS = "x-validate-by-groups";
+
+    /**
+     * Custom attribute for specifying superclass.
+     * @deprecated Use {@link #X_EXTENDS} instead.
+     */
+    @Deprecated
+    public static final String EXTENDS = "extends";
+    /** Custom attribute for specifying superclass (x- prefix). */
+    public static final String X_EXTENDS = "x-extends";
+
+    /**
+     * Custom attribute for specifying implemented interfaces.
+     * @deprecated Use {@link #X_IMPLEMENTS} instead.
+     */
+    @Deprecated
+    public static final String IMPLEMENTS = "implements";
+    /** Custom attribute for specifying implemented interfaces (x- prefix). */
+    public static final String X_IMPLEMENTS = "x-implements";
+
+    /**
+     * Custom attribute for external class reference.
+     * @deprecated Use {@link #X_FROM_CLASS} instead.
+     */
+    @Deprecated
+    public static final String FROM_CLASS = "fromClass";
+    /** Custom attribute for external class reference (x- prefix). */
+    public static final String X_FROM_CLASS = "x-from-class";
+
+    /**
+     * Custom attribute for external class package.
+     * @deprecated Use {@link #X_FROM_PACKAGE} instead.
+     */
+    @Deprecated
+    public static final String FROM_PACKAGE = "fromPackage";
+    /** Custom attribute for external class package (x- prefix). */
+    public static final String X_FROM_PACKAGE = "x-from-package";
+
+    /**
+     * Custom attribute for external interface reference.
+     * @deprecated Use {@link #X_FROM_INTERFACE} instead.
+     */
+    @Deprecated
+    public static final String FROM_INTERFACE = "fromInterface";
+    /** Custom attribute for external interface reference (x- prefix). */
+    public static final String X_FROM_INTERFACE = "x-from-interface";
+
+    /**
+     * Custom attribute for method definition.
+     * @deprecated Use {@link #X_DEFINITION} instead.
+     */
+    @Deprecated
+    public static final String DEFINITION = "definition";
+    /** Custom attribute for method definition (x- prefix). */
+    public static final String X_DEFINITION = "x-definition";
+
+    /**
+     * Custom attribute for schema removal flag.
+     * @deprecated Use {@link #X_REMOVE_SCHEMA} instead.
+     */
+    @Deprecated
+    public static final String REMOVE_SCHEMA = "removeSchema";
+    /** Custom attribute for schema removal flag (x- prefix). */
+    public static final String X_REMOVE_SCHEMA = "x-remove-schema";
+
+    /**
+     * Custom attribute for digits validation.
+     * @deprecated Use {@link #X_DIGITS} instead.
+     */
+    @Deprecated
+    public static final String DIGITS = "digits";
+    /** Custom attribute for digits validation (x- prefix). */
+    public static final String X_DIGITS = "x-digits";
+
+    /**
+     * Custom attribute for additional format specification.
+     * @deprecated Use {@link #X_ADDITIONAL_FORMAT} instead.
+     */
+    @Deprecated
+    public static final String ADDITIONAL_FORMAT = "additionalFormat";
+    /** Custom attribute for additional format specification (x- prefix). */
+    public static final String X_ADDITIONAL_FORMAT = "x-additional-format";
+
+    /**
+     * Custom attribute for method definition in interfaces.
+     * @deprecated Use {@link #X_METHODS} instead.
+     */
+    @Deprecated
+    public static final String METHODS = "methods";
+    /** Custom attribute for method definition in interfaces (x- prefix). */
+    public static final String X_METHODS = "x-methods";
+
+    /**
+     * Custom attribute for imports in interfaces.
+     * @deprecated Use {@link #X_IMPORTS} instead.
+     */
+    @Deprecated
+    public static final String IMPORTS = "imports";
+    /** Custom attribute for imports in interfaces (x- prefix). */
+    public static final String X_IMPORTS = "x-imports";
+
+    /**
+     * Custom attribute for message generation path.
+     * @deprecated Use {@link #X_PATH_FOR_GENERATE_MESSAGE} instead.
+     */
+    @Deprecated
+    public static final String PATH_FOR_GENERATE_MESSAGE = "pathForGenerateMessage";
+    /** Custom attribute for message generation path (x- prefix). */
+    public static final String X_PATH_FOR_GENERATE_MESSAGE = "x-path-for-generate-message";
+
+    // ============================================================
+    // Lombok config keys — Group 3
+    // ============================================================
+
+    /**
+     * Lombok configuration root key.
+     * @deprecated Use {@link #X_LOMBOK} instead.
+     */
+    @Deprecated
+    public static final String LOMBOK = "lombok";
+    /** Lombok configuration root key (x- prefix). */
+    public static final String X_LOMBOK = "x-lombok";
     /**
      * YAML property name for minimum value constraint
      */
@@ -152,10 +314,6 @@ public final class Dictionary {
      */
     public static final String ADDITIONAL_PROPERTIES = "additionalProperties";
     /**
-     * Custom YAML property name for additional format specification
-     */
-    public static final String ADDITIONAL_FORMAT = "additionalFormat";
-    /**
      * YAML property name for default value
      */
     public static final String DEFAULT = "default";
@@ -181,70 +339,19 @@ public final class Dictionary {
     public static final List<String> POLYMORPHS = List.of(ALL_OF, ONE_OF, ANY_OF);
 
     /**
-     * Custom YAML extension attributes supported by Yojo generator.
-     */
-    /**
-     * Custom attribute for specifying collection implementation
-     */
-    public static final String REALIZATION = "realization";
-    /**
-     * Custom attribute for validation groups
-     */
-    public static final String VALIDATION_GROUPS = "validationGroups";
-    /**
-     * Custom attribute for validation groups imports
-     */
-    public static final String VALIDATION_GROUPS_IMPORTS = "validationGroupsImports";
-    /**
-     * Custom attribute for enabling validation by groups
-     */
-    public static final String VALIDATE_BY_GROUPS = "validateByGroups";
-    /**
-     * Custom attribute for specifying superclass
-     */
-    public static final String EXTENDS = "extends";
-    /**
-     * Custom attribute for specifying implemented interfaces
-     */
-    public static final String IMPLEMENTS = "implements";
-    /**
-     * Custom attribute for external class reference
-     */
-    public static final String FROM_CLASS = "fromClass";
-    /**
-     * Custom attribute for external class package
-     */
-    public static final String FROM_PACKAGE = "fromPackage";
-    /**
-     * Custom attribute for external interface reference
-     */
-    public static final String FROM_INTERFACE = "fromInterface";
-    /**
-     * Custom attribute for package specification
+     * Custom attribute for package specification (used in format: existing / $ref items)
      */
     public static final String PACKAGE = "package";
     /**
-     * Custom attribute for existing type reference
+     * Custom attribute for existing type reference (format value: existing)
      */
     public static final String EXISTING = "existing";
     /**
-     * Custom attribute for interface type
+     * Custom attribute for interface type (format value: interface)
      */
     public static final String INTERFACE = "interface";
     /**
-     * Custom attribute for method definition
-     */
-    public static final String DEFINITION = "definition";
-    /**
-     * Custom attribute for schema removal flag
-     */
-    public static final String REMOVE_SCHEMA = "removeSchema";
-    /**
-     * Custom attribute for digits validation
-     */
-    public static final String DIGITS = "digits";
-    /**
-     * Custom attribute for multiple of validation
+     * Custom attribute for multiple of validation (standard JSON Schema, no x- prefix needed)
      */
     public static final String MULTIPLE_OF = "multipleOf";
     /**
@@ -261,41 +368,41 @@ public final class Dictionary {
 
     /**
      * Lombok configuration keys (manual override section).
+     *
+     * <p>The parent key {@code lombok} is deprecated in favour of {@link #X_LOMBOK}.
+     * Nested keys within the block are unchanged.</p>
      */
+    // LOMBOK / X_LOMBOK declared above in the extension attributes section (§Groups 1-3)
     /**
-     * Lombok configuration root key
-     */
-    public static final String LOMBOK = "lombok";
-    /**
-     * Enable Lombok flag
+     * Enable Lombok flag (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String ENABLE = "enable";
     /**
-     * Lombok accessors configuration
+     * Lombok accessors configuration (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String ACCESSORS = "accessors";
     /**
-     * Lombok fluent accessors flag
+     * Lombok fluent accessors flag (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String FLUENT = "fluent";
     /**
-     * Lombok chain accessors flag
+     * Lombok chain accessors flag (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String CHAIN = "chain";
     /**
-     * Lombok equals and hashCode flag
+     * Lombok equals and hashCode flag (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String EQUALS_AND_HASH_CODE = "equalsAndHashCode";
     /**
-     * Lombok callSuper flag for equals and hashCode
+     * Lombok callSuper flag for equals and hashCode (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String CALL_SUPER = "callSuper";
     /**
-     * Lombok all args constructor flag
+     * Lombok all args constructor flag (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String ALL_ARGS = "allArgsConstructor";
     /**
-     * Lombok no args constructor flag
+     * Lombok no args constructor flag (nested inside {@code lombok} / {@code x-lombok})
      */
     public static final String NO_ARGS = "noArgsConstructor";
 
@@ -994,15 +1101,6 @@ public final class Dictionary {
      * Public interface declaration
      */
     public static final String PUBLIC_INTERFACE = "public interface ";
-    /**
-     * Methods property name
-     */
-    public static final String METHODS = "methods";
-    /**
-     * Imports property name
-     */
-    public static final String IMPORTS = "imports";
-
     /**
      * Reserved Java keywords (used to avoid invalid field names).
      */

--- a/src/main/java/ru/yojo/codegen/generator/code/SchemaCodeGenerator.java
+++ b/src/main/java/ru/yojo/codegen/generator/code/SchemaCodeGenerator.java
@@ -15,6 +15,7 @@ import static java.lang.System.lineSeparator;
 import static ru.yojo.codegen.constants.Dictionary.*;
 import static ru.yojo.codegen.util.MapperUtil.castObjectToMap;
 import static ru.yojo.codegen.util.MapperUtil.getStringValueIfExistOrElseNull;
+import static ru.yojo.codegen.util.MapperUtil.getXValueOrElseDeprecated;
 
 /**
  * Generates Java source code for a {@link Schema} object.
@@ -382,7 +383,7 @@ public class SchemaCodeGenerator extends AbstractCodeGenerator {
             methods.values().forEach(method -> {
                 Map<String, Object> currentMethod = castObjectToMap(method);
                 String methodDescription = getStringValueIfExistOrElseNull(DESCRIPTION, currentMethod);
-                String methodDefinition = getStringValueIfExistOrElseNull(DEFINITION, currentMethod);
+                String methodDefinition = getXValueOrElseDeprecated(X_DEFINITION, DEFINITION, currentMethod, null);
                 if (methodDescription != null) {
                     generateClassJavaDoc(stringBuilder, methodDescription);
                 }

--- a/src/main/java/ru/yojo/codegen/mapper/AbstractMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/AbstractMapper.java
@@ -125,7 +125,7 @@ public class AbstractMapper {
         variableProperties.setDescription(getStringValueIfExistOrElseNull(DESCRIPTION, propertiesMap));
         variableProperties.setExample(getStringValueIfExistOrElseNull(EXAMPLE, propertiesMap));
         variableProperties.setTitle(getStringValueIfExistOrElseNull(TITLE, propertiesMap));
-        variableProperties.setDigits(getStringValueIfExistOrElseNull(DIGITS, propertiesMap));
+        variableProperties.setDigits(getXValueOrElseDeprecated(X_DIGITS, DIGITS, propertiesMap, LOG));
         variableProperties.setMultipleOf(getStringValueIfExistOrElseNull(MULTIPLE_OF, propertiesMap));
         variableProperties.setMinimum(getStringValueIfExistOrElseNull(MINIMUM, propertiesMap));
         variableProperties.setMaximum(getStringValueIfExistOrElseNull(MAXIMUM, propertiesMap));
@@ -243,7 +243,7 @@ public class AbstractMapper {
         String format = variableProperties.getFormat();
         String referencedObject = getStringValueIfExistOrElseNull(REFERENCE, additionalPropertiesMap);
         variableProperties.addRequiredImports(MAP_IMPORT);
-        variableProperties.setRealisation(getStringValueIfExistOrElseNull(REALIZATION, propertiesMap));
+        variableProperties.setRealisation(getXValueOrElseDeprecated(X_REALIZATION, REALIZATION, propertiesMap, LOG));
         variableProperties.setValid(false);
         if (type != null && JAVA_LOWER_CASE_TYPES_CHECK_CONVERTER.containsKey(type)) {
             LOG.debug("CORRECT TYPE!");
@@ -288,7 +288,7 @@ public class AbstractMapper {
                 if (collectionType != null) {
                     variableProperties.setCollectionType(collectionType);
                 }
-                String javaType = getStringValueIfExistOrElseNull(ADDITIONAL_FORMAT, additionalPropertiesMap);
+                String javaType = getXValueOrElseDeprecated(X_ADDITIONAL_FORMAT, ADDITIONAL_FORMAT, additionalPropertiesMap, LOG);
                 if (javaType != null && JAVA_LOWER_CASE_TYPES_CHECK_CONVERTER.containsKey(javaType)) {
                     if (format != null) {
                         variableProperties.setItems(JAVA_LOWER_CASE_TYPES_CHECK_CONVERTER.get(javaType).toString());
@@ -327,12 +327,13 @@ public class AbstractMapper {
                     variableProperties.addRequiredImports(prepareImport(processContext, refObjectName));
                 }
             }
-        } else if (ARRAY.equals(type) && getStringValueIfExistOrElseNull(ADDITIONAL_FORMAT, additionalPropertiesMap) != null) {
+        } else if (ARRAY.equals(type) && getXValueOrElseDeprecated(X_ADDITIONAL_FORMAT, ADDITIONAL_FORMAT, additionalPropertiesMap, null) != null) {
             String collectionType = getStringValueIfExistOrElseNull(FORMAT, additionalPropertiesMap);
             if (collectionType != null) {
                 variableProperties.setCollectionType(collectionType);
             }
-            variableProperties.setItems(JAVA_LOWER_CASE_TYPES_CHECK_CONVERTER.get(getStringValueIfExistOrElseNull(ADDITIONAL_FORMAT, additionalPropertiesMap)).toString());
+            String additionalFormatValue = getXValueOrElseDeprecated(X_ADDITIONAL_FORMAT, ADDITIONAL_FORMAT, additionalPropertiesMap, LOG);
+            variableProperties.setItems(JAVA_LOWER_CASE_TYPES_CHECK_CONVERTER.get(additionalFormatValue).toString());
             fillCollectionType(variableProperties);
             if (format != null) {
                 variableProperties.setType(format(MAP_CUSTOM_TYPE,
@@ -527,7 +528,12 @@ public class AbstractMapper {
                                      ProcessContext processContext,
                                      Map<String, Object> innerSchemas) {
         Map<String, Object> items = castObjectToMap(propertiesMap.get(ITEMS));
-        variableProperties.setRealisation(getStringValueIfExistOrElseNull(REALIZATION, items));
+        String realizationValue = getXValueOrElseDeprecated(X_REALIZATION, REALIZATION, items, LOG);
+        if (realizationValue == null) {
+            // Also check top-level propertiesMap for realization (used with maps)
+            realizationValue = getXValueOrElseDeprecated(X_REALIZATION, REALIZATION, propertiesMap, null);
+        }
+        variableProperties.setRealisation(realizationValue);
         String refValue = getStringValueIfExistOrElseNull(REFERENCE, items);
         String collectionFormat = getStringValueIfExistOrElseNull(FORMAT, propertiesMap);
         boolean javaType = false;
@@ -654,8 +660,9 @@ public class AbstractMapper {
                       key.equals(EXAMPLE) || key.equals(DEFAULT) || key.equals(PATTERN) ||
                       key.equals(MIN_LENGTH) || key.equals(MAX_LENGTH) ||
                       key.equals(MINIMUM) || key.equals(MAXIMUM) ||
-                      key.equals(DIGITS) ||
-                      key.equals(REALIZATION) || key.equals(NAME) || key.equals(PACKAGE))) {
+                      key.equals(DIGITS) || key.equals(X_DIGITS) ||
+                      key.equals(REALIZATION) || key.equals(X_REALIZATION) ||
+                      key.equals(NAME) || key.equals(PACKAGE))) {
                     actualProps.put(key, entry.getValue());
                     it.remove();
                 }
@@ -899,9 +906,9 @@ public class AbstractMapper {
         Set<String> annotationSet = new HashSet<>();
         Set<String> importSet = new HashSet<>();
         Set<String> requiredAttributes = getSetValueIfExistsOrElseEmptySet(REQUIRED, currentSchema);
-        Set<String> validationGroups = getSetValueIfExistsOrElseEmptySet(VALIDATION_GROUPS, currentSchema);
-        Set<String> validationGroupsImports = getSetValueIfExistsOrElseEmptySet(VALIDATION_GROUPS_IMPORTS, currentSchema);
-        Set<String> validationFields = getSetValueIfExistsOrElseEmptySet(VALIDATE_BY_GROUPS, currentSchema);
+        Set<String> validationGroups = getXSetValueOrElseDeprecated(X_VALIDATION_GROUPS, VALIDATION_GROUPS, currentSchema, LOG);
+        Set<String> validationGroupsImports = getXSetValueOrElseDeprecated(X_VALIDATION_GROUPS_IMPORTS, VALIDATION_GROUPS_IMPORTS, currentSchema, LOG);
+        Set<String> validationFields = getXSetValueOrElseDeprecated(X_VALIDATE_BY_GROUPS, VALIDATE_BY_GROUPS, currentSchema, LOG);
         String groups = null;
         if (!validationGroups.isEmpty()) {
             if (validationGroupsImports.isEmpty() || validationFields.isEmpty()) {

--- a/src/main/java/ru/yojo/codegen/mapper/MessageMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/MessageMapper.java
@@ -150,13 +150,13 @@ public class MessageMapper extends AbstractMapper {
                     if (refObject != null) {
                         Map<String, Object> refMap = castObjectToMap(processContext.getSchemasMap().get(refReplace(refObject)));
                         refMap.forEach((mk, mv) -> {
-                            if (mk.equals(EXTENDS)) {
+                            if (mk.equals(EXTENDS) || mk.equals(X_EXTENDS)) {
                                 String fromClass = prepareExtendsMessage(builder, mv, processContext);
                                 if (refObject != null && refReplace(refObject).equals(fromClass)) {
                                     needToFill.set(false);
                                 }
                             }
-                            if (mk.equals(IMPLEMENTS)) {
+                            if (mk.equals(IMPLEMENTS) || mk.equals(X_IMPLEMENTS)) {
                                 prepareImplementsMessage(builder, mv);
                             }
                         });
@@ -193,7 +193,16 @@ public class MessageMapper extends AbstractMapper {
      */
     private static void prepareImplementsMessage(MessageBuilder builder, Object mv) {
         Map<String, Object> implementsMap = castObjectToMap(mv);
-        List<String> fromInterfaceList = castObjectToList(implementsMap.get(FROM_INTERFACE));
+        Object fromInterfaceObj;
+        if (implementsMap.containsKey(X_FROM_INTERFACE)) {
+            fromInterfaceObj = implementsMap.get(X_FROM_INTERFACE);
+        } else {
+            if (implementsMap.containsKey(FROM_INTERFACE)) {
+                LOG.warn("Attribute 'fromInterface' is deprecated, use 'x-from-interface' instead");
+            }
+            fromInterfaceObj = implementsMap.get(FROM_INTERFACE);
+        }
+        List<String> fromInterfaceList = castObjectToList(fromInterfaceObj);
         LOG.info("SHOULD IMPLEMENTS FROM: " + fromInterfaceList);
         fromInterfaceList.forEach(ifc -> {
             String[] split = ifc.split("[.]");
@@ -212,8 +221,8 @@ public class MessageMapper extends AbstractMapper {
      */
     private static String prepareExtendsMessage(MessageBuilder builder, Object mv, ProcessContext processContext) {
         Map<String, Object> extendsMap = castObjectToMap(mv);
-        String fromClass = getStringValueIfExistOrElseNull(FROM_CLASS, extendsMap);
-        String fromPackage = getStringValueIfExistOrElseNull(FROM_PACKAGE, extendsMap);
+        String fromClass = getXValueOrElseDeprecated(X_FROM_CLASS, FROM_CLASS, extendsMap, LOG);
+        String fromPackage = getXValueOrElseDeprecated(X_FROM_PACKAGE, FROM_PACKAGE, extendsMap, LOG);
         LOG.info("SHOULD EXTENDS FROM: " + fromClass);
         if (fromClass != null && processContext.getSchemasMap().containsKey(fromClass)) {
             fromPackage = null;
@@ -250,14 +259,14 @@ public class MessageMapper extends AbstractMapper {
                                               AtomicBoolean needToFill,
                                               ProcessContext processContext) {
         payloadMap.forEach((mk, mv) -> {
-            if (mk.equals(EXTENDS)) {
+            if (mk.equals(EXTENDS) || mk.equals(X_EXTENDS)) {
                 String fromClass = prepareExtendsMessage(builder, mv, processContext);
                 if (refObject != null && refReplace(refObject).equals(fromClass)) {
                     needToFill.set(false);
                     excludeInheritanceSchemas.add(refReplace(refObject));
                 }
             }
-            if (mk.equals(IMPLEMENTS)) {
+            if (mk.equals(IMPLEMENTS) || mk.equals(X_IMPLEMENTS)) {
                 prepareImplementsMessage(builder, mv);
             }
         });
@@ -295,8 +304,16 @@ public class MessageMapper extends AbstractMapper {
                                              LombokProperties lombokProperties) {
         FillParameters parameters = new FillParameters();
 
-        if (payload.containsKey(LOMBOK)) {
-            Map<String, Object> lombokProps = castObjectToMap(payload.get(LOMBOK));
+        Map<String, Object> lombokProps;
+        if (payload.containsKey(X_LOMBOK)) {
+            lombokProps = castObjectToMap(payload.get(X_LOMBOK));
+        } else if (payload.containsKey(LOMBOK)) {
+            LOG.warn("Attribute 'lombok' is deprecated, use 'x-lombok' instead");
+            lombokProps = castObjectToMap(payload.get(LOMBOK));
+        } else {
+            lombokProps = new LinkedHashMap<>();
+        }
+        if (!lombokProps.isEmpty()) {
             if (lombokProps.containsKey(ENABLE) &&
                 "false".equals(getStringValueIfExistOrElseNull(ENABLE, lombokProps))) {
                 lombokProperties.setEnableLombok(Boolean.valueOf(getStringValueIfExistOrElseNull(ENABLE, lombokProps)));
@@ -433,8 +450,8 @@ public class MessageMapper extends AbstractMapper {
                     processContext,
                     innerSchemas
             );
-            if (getStringValueIfExistOrElseNull(REMOVE_SCHEMA, payload) != null &&
-                getStringValueIfExistOrElseNull(REMOVE_SCHEMA, payload).equals("true")) {
+            String removeSchemaVal = getXValueOrElseDeprecated(X_REMOVE_SCHEMA, REMOVE_SCHEMA, payload, LOG);
+            if (removeSchemaVal != null && "true".equals(removeSchemaVal)) {
                 removeSchemas.add(schemaName);
             }
             if (!innerSchemas.isEmpty()) {

--- a/src/main/java/ru/yojo/codegen/mapper/SchemaMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/SchemaMapper.java
@@ -75,15 +75,23 @@ public class SchemaMapper extends AbstractMapper {
                         .fillParameters(new FillParameters(new ArrayList<>()))
                         .isInterface(true)
                         .description(getStringValueIfExistOrElseNull(DESCRIPTION, schemaMap))
-                        .methods(castObjectToMap(schemaMap.get(METHODS)))
-                        .interfaceImports(getSetValueIfExistsOrElseEmptySet(IMPORTS, schemaMap))
+                        .methods(castObjectToMap(schemaMap.getOrDefault(X_METHODS, schemaMap.get(METHODS))))
+                        .interfaceImports(getXSetValueOrElseDeprecated(X_IMPORTS, IMPORTS, schemaMap, LOG))
                         .build();
                 schemaList.add(schema);
                 return;
             }
 
-            if (schemaMap != null && schemaMap.containsKey(LOMBOK)) {
-                Map<String, Object> lombokProps = castObjectToMap(schemaMap.get(LOMBOK));
+            Map<String, Object> lombokProps;
+            if (schemaMap != null && schemaMap.containsKey(X_LOMBOK)) {
+                lombokProps = castObjectToMap(schemaMap.get(X_LOMBOK));
+            } else if (schemaMap != null && schemaMap.containsKey(LOMBOK)) {
+                LOG.warn("Attribute 'lombok' is deprecated, use 'x-lombok' instead");
+                lombokProps = castObjectToMap(schemaMap.get(LOMBOK));
+            } else {
+                lombokProps = new LinkedHashMap<>();
+            }
+            if (!lombokProps.isEmpty()) {
                 if (lombokProps.containsKey(ENABLE) &&
                     "false".equals(getStringValueIfExistOrElseNull(ENABLE, lombokProps))) {
                     finalLombokProperties.setEnableLombok(Boolean.valueOf(getStringValueIfExistOrElseNull(ENABLE, lombokProps)));
@@ -103,10 +111,10 @@ public class SchemaMapper extends AbstractMapper {
 
                 AtomicBoolean needToFill = new AtomicBoolean(true);
                 schemaMap.forEach((sk, sv) -> {
-                    if (sk.equals(EXTENDS)) {
+                    if (sk.equals(EXTENDS) || sk.equals(X_EXTENDS)) {
                         Map<String, Object> extendsMap = castObjectToMap(sv);
-                        String fromClass = getStringValueIfExistOrElseNull(FROM_CLASS, extendsMap);
-                        String fromPackage = getStringValueIfExistOrElseNull(FROM_PACKAGE, extendsMap);
+                        String fromClass = getXValueOrElseDeprecated(X_FROM_CLASS, FROM_CLASS, extendsMap, LOG);
+                        String fromPackage = getXValueOrElseDeprecated(X_FROM_PACKAGE, FROM_PACKAGE, extendsMap, LOG);
                         LOG.info("SHOULD EXTENDS FROM: " + fromClass);
                         builder.extendsFrom(fromClass);
                         if (fromPackage != null) {
@@ -120,9 +128,18 @@ public class SchemaMapper extends AbstractMapper {
                             needToFill.set(false);
                         }
                     }
-                    if (sk.equals(IMPLEMENTS)) {
+                    if (sk.equals(IMPLEMENTS) || sk.equals(X_IMPLEMENTS)) {
                         Map<String, Object> implementsMap = castObjectToMap(sv);
-                        List<String> fromInterfaceList = castObjectToList(implementsMap.get(FROM_INTERFACE));
+                        Object fromInterfaceObj;
+                        if (implementsMap.containsKey(X_FROM_INTERFACE)) {
+                            fromInterfaceObj = implementsMap.get(X_FROM_INTERFACE);
+                        } else {
+                            if (implementsMap.containsKey(FROM_INTERFACE)) {
+                                LOG.warn("Attribute 'fromInterface' is deprecated, use 'x-from-interface' instead");
+                            }
+                            fromInterfaceObj = implementsMap.get(FROM_INTERFACE);
+                        }
+                        List<String> fromInterfaceList = castObjectToList(fromInterfaceObj);
                         LOG.info("SHOULD IMPLEMENTS FROM: " + fromInterfaceList);
                         fromInterfaceList.forEach(ifc -> {
                             String[] split = ifc.split("[.]");
@@ -150,7 +167,7 @@ public class SchemaMapper extends AbstractMapper {
 
                 // ——— Discriminator: set extendsFrom on subtypes referencing a discriminator base ——— //
                 // (only if no explicit extends was defined in the YAML)
-                if (!schemaMap.containsKey(EXTENDS)) {
+                if (!schemaMap.containsKey(EXTENDS) && !schemaMap.containsKey(X_EXTENDS)) {
                     for (String polyKey : POLYMORPHS) {
                         if (schemaMap.containsKey(polyKey)) {
                             List<Object> items = castObjectToListObjects(schemaMap.get(polyKey));

--- a/src/main/java/ru/yojo/codegen/util/MapperUtil.java
+++ b/src/main/java/ru/yojo/codegen/util/MapperUtil.java
@@ -59,6 +59,58 @@ public class MapperUtil {
     }
 
     /**
+     * Backward-compatible attribute reader: try the new {@code x-} prefixed key first,
+     * fall back to the deprecated old key with a warning.
+     *
+     * @param xKey  the new key with {@code x-} prefix (e.g. {@code "x-realization"})
+     * @param oldKey the deprecated old key (e.g. {@code "realization"})
+     * @param map   source YAML map
+     * @param log   logger for deprecation warnings (may be {@code null})
+     * @return attribute string value, or {@code null} if neither key exists
+     */
+    public static String getXValueOrElseDeprecated(String xKey, String oldKey,
+                                                    Map<String, Object> map,
+                                                    Logger log) {
+        if (map.containsKey(xKey)) {
+            Object value = map.get(xKey);
+            return value != null ? value.toString() : null;
+        }
+        if (map.containsKey(oldKey)) {
+            if (log != null) {
+                log.warn("Attribute '" + oldKey + "' is deprecated, use '" + xKey + "' instead");
+            }
+            Object value = map.get(oldKey);
+            return value != null ? value.toString() : null;
+        }
+        return null;
+    }
+
+    /**
+     * Backward-compatible set reader: try the new {@code x-} prefixed key first,
+     * fall back to the deprecated old key with a warning.
+     *
+     * @param xKey  the new key with {@code x-} prefix (e.g. {@code "x-validationGroups"})
+     * @param oldKey the deprecated old key (e.g. {@code "validationGroups"})
+     * @param map   source YAML map
+     * @param log   logger for deprecation warnings (may be {@code null})
+     * @return non-null set of strings
+     */
+    public static Set<String> getXSetValueOrElseDeprecated(String xKey, String oldKey,
+                                                            Map<String, Object> map,
+                                                            Logger log) {
+        if (map.containsKey(xKey)) {
+            return new HashSet<>((ArrayList<String>) map.get(xKey));
+        }
+        if (map.containsKey(oldKey)) {
+            if (log != null) {
+                log.warn("Attribute '" + oldKey + "' is deprecated, use '" + xKey + "' instead");
+            }
+            return new HashSet<>((ArrayList<String>) map.get(oldKey));
+        }
+        return new HashSet<>();
+    }
+
+    /**
      * Casts an object to {@code Map<String, Object>}, returning an empty map if {@code null}.
      *
      * @param obj object to cast

--- a/src/test/java/ru/yojo/codegen/generator/XAttributesTest.java
+++ b/src/test/java/ru/yojo/codegen/generator/XAttributesTest.java
@@ -1,0 +1,194 @@
+package ru.yojo.codegen.generator;
+
+import org.junit.jupiter.api.*;
+import ru.yojo.codegen.context.SpecificationProperties;
+import ru.yojo.codegen.context.YojoContext;
+import ru.yojo.codegen.domain.ValidationApi;
+import ru.yojo.codegen.domain.lombok.Accessors;
+import ru.yojo.codegen.domain.lombok.LombokProperties;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for backward-compatible x- prefixed attribute support.
+ * <p>
+ * Verifies that new x- prefixed attribute names (e.g. {@code x-realization}, {@code x-digits})
+ * produce the same generated code as the deprecated old names.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class XAttributesTest {
+
+    private final YojoGenerator yojoGenerator = new YojoGenerator();
+    private static final String BASE_DIR = "src/test/resources/example/testGenerate/xattr/";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // Clean output directory before each test
+        Path path = Paths.get(BASE_DIR);
+        if (Files.exists(path)) {
+            try (Stream<Path> walk = Files.walk(path)) {
+                walk.sorted((a, b) -> -a.compareTo(b))
+                        .forEach(p -> {
+                            try { Files.deleteIfExists(p); } catch (IOException ignore) {}
+                        });
+            }
+        }
+    }
+
+    private void generate() throws IOException {
+        SpecificationProperties spec = new SpecificationProperties();
+        spec.setSpecName("x-attributes.yaml");
+        spec.setInputDirectory("src/test/resources/example/contract/x-attr");
+        spec.setOutputDirectory(BASE_DIR);
+        spec.setPackageLocation("example.testGenerate.xattr");
+
+        YojoContext ctx = new YojoContext();
+        ctx.setSpecificationProperties(Collections.singletonList(spec));
+        ctx.setLombokProperties(new LombokProperties(false, false, new Accessors(false, false, false)));
+        ctx.setValidationApi(ValidationApi.JAKARTA);
+        yojoGenerator.generateAll(ctx);
+    }
+
+    private String readFile(String relativePath) throws IOException {
+        return Files.readString(Paths.get(BASE_DIR + relativePath));
+    }
+
+    @Test
+    @Order(1)
+    void xDigitsProducesCorrectAnnotation() throws IOException {
+        generate();
+
+        String nv = readFile("common/NumericValues.java");
+        // x-digits: "integer=5, fraction=0" → @Digits(integer=5, fraction=0)
+        assertThat(nv)
+                .contains("@Digits(integer = 5, fraction = 0)")
+                .contains("private Long quantity;");
+    }
+
+    @Test
+    @Order(2)
+    void xRealizationOnItems() throws IOException {
+        generate();
+
+        String ce = readFile("common/CollectionExample.java");
+        assertThat(ce)
+                .contains("private List<Long> ids = new ArrayList<>();")
+                .contains("private Set<String> names = new HashSet<>();")
+                .contains("import java.util.ArrayList;")
+                .contains("import java.util.HashSet;");
+    }
+
+    @Test
+    @Order(3)
+    void xRealizationOnMap() throws IOException {
+        generate();
+
+        String me = readFile("common/MapExample.java");
+        assertThat(me)
+                .contains("import java.util.LinkedHashMap;")
+                .contains("private Map<String, Integer> scores = new LinkedHashMap<>();");
+    }
+
+    @Test
+    @Order(4)
+    void xLombokDisablesLombok() throws IOException {
+        generate();
+
+        String nv = readFile("common/NumericValues.java");
+        // x-lombok: enable=false → no @Data/@Getter etc.
+        assertThat(nv)
+                .doesNotContain("@Data")
+                .doesNotContain("@Getter");
+    }
+
+    @Test
+    @Order(5)
+    void xValidationGroupsOnSchema() throws IOException {
+        generate();
+
+        String rs = readFile("common/RequestDtoSchema.java");
+        // x-validation-groups + x-validation-groups-imports + x-validate-by-groups
+        assertThat(rs)
+                .contains("@NotNull(groups = {Create.class})")
+                .contains("import com.example.Validation;")
+                .contains("private Integer integerValidationField;");
+    }
+
+    @Test
+    @Order(6)
+    void xExtendsWithXFromClass() throws IOException {
+        generate();
+
+        String dc = readFile("common/DerivedClass.java");
+        assertThat(dc)
+                .contains("extends BaseClass")
+                .contains("private String derivedField;");
+        // BaseClass is in the same .common package
+        assertThat(dc)
+                .contains("import example.testGenerate.xattr.common.BaseClass;");
+    }
+
+    @Test
+    @Order(7)
+    void xMethodsWithXDefinition() throws IOException {
+        generate();
+
+        String iface = readFile("common/InterfaceWithMethods.java");
+        assertThat(iface)
+                .contains("void doSomething(String input);");
+    }
+
+    @Test
+    @Order(8)
+    void allGeneratedCodeCompiles() throws IOException {
+        generate();
+
+        // Collect all generated .java files
+        // Exclude RequestDtoSchema which references com.example.Validation/Create (not on test classpath)
+        List<Path> javaFiles;
+        try (Stream<Path> walk = Files.walk(Paths.get(BASE_DIR))) {
+            javaFiles = walk
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> !p.getFileName().toString().contains("RequestDtoSchema"))
+                    .toList();
+        }
+
+        assertThat(javaFiles).isNotEmpty();
+
+        // Verify compilation
+        javax.tools.JavaCompiler compiler = javax.tools.ToolProvider.getSystemJavaCompiler();
+        javax.tools.DiagnosticCollector<javax.tools.JavaFileObject> diagnostics = new javax.tools.DiagnosticCollector<>();
+        javax.tools.StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+        Iterable<? extends javax.tools.JavaFileObject> compilationUnits =
+                fileManager.getJavaFileObjectsFromPaths(javaFiles);
+
+        javax.tools.JavaCompiler.CompilationTask task =
+                compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnits);
+        boolean compiled = task.call();
+
+        if (!compiled) {
+            StringBuilder sb = new StringBuilder("COMPILATION FAILED:\n");
+            for (javax.tools.Diagnostic<? extends javax.tools.JavaFileObject> d : diagnostics.getDiagnostics()) {
+                sb.append(String.format("[%s] %s:%d:%d: %s%n",
+                        d.getKind(),
+                        d.getSource() != null ? d.getSource().getName() : "unknown",
+                        d.getLineNumber(),
+                        d.getColumnNumber(),
+                        d.getMessage(null)));
+            }
+            Assertions.fail(sb.toString());
+        }
+
+        assertTrue(compiled, "All generated code with x- attributes must compile");
+    }
+}

--- a/src/test/resources/example/contract/x-attr/x-attributes.yaml
+++ b/src/test/resources/example/contract/x-attr/x-attributes.yaml
@@ -1,0 +1,91 @@
+asyncapi: 2.0.0
+info:
+  title: X-Attributes Test
+  version: 1.0.0
+  description: "Contract for testing x- prefixed attributes backward compatibility"
+channels: {}
+components:
+  schemas:
+    NumericValues:
+      type: object
+      properties:
+        price:
+          type: number
+          format: big-decimal
+          x-multiple-of: 0.01
+        quantity:
+          type: integer
+          format: int64
+          x-digits: "integer = 5, fraction = 0"
+      x-lombok:
+        enable: false
+
+    CollectionExample:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int64
+            x-realization: ArrayList
+        names:
+          type: array
+          format: set
+          items:
+            type: string
+            x-realization: HashSet
+
+    MapExample:
+      type: object
+      properties:
+        scores:
+          type: object
+          additionalProperties:
+            type: integer
+          x-realization: LinkedHashMap
+
+    RequestDtoSchema:
+      type: object
+      properties:
+        x-digits:
+          type: number
+          format: big-decimal
+        stringValueWithRequired:
+          type: string
+        integerValidationField:
+          type: integer
+      required:
+        - stringValueWithRequired
+        - integerValidationField
+      x-validation-groups:
+        - Create.class
+      x-validation-groups-imports:
+        - com.example.Validation
+      x-validate-by-groups:
+        - integerValidationField
+
+    BaseClass:
+      type: object
+      properties:
+        baseField:
+          type: string
+
+    DerivedClass:
+      type: object
+      properties:
+        derivedField:
+          type: string
+      x-extends:
+        x-from-class: BaseClass
+        x-from-package: example.testGenerate.xattr.common
+
+    InterfaceWithMethods:
+      type: object
+      format: interface
+      x-methods:
+        doSomething:
+          description: Do something
+          x-definition: "void doSomething(String input);"
+      x-imports:
+        - java.util.List


### PR DESCRIPTION
…iants (Issue #38)

- Add x- prefixed constants (x-realization, x-digits, x-additional-format, etc.)
- Mark old constants as @Deprecated with javadoc pointing to replacements
- Backward-compatible reading logic: try x- key first, fall back to old key with WARN
- Update AbstractMapper, SchemaMapper, MessageMapper for all deprecated attributes
- Add XAttributesTest with x-attribute YAML contract
- Bump minor version to 4.3.0