### PR TITLE
fix: array-of-boolean import and enum-ARRAY collision bugs

### DIFF
--- a/prod-offer-issue-contract.yaml
+++ b/prod-offer-issue-contract.yaml
@@ -1,0 +1,79 @@
+asyncapi: '2.6.0'
+info:
+  title: Product Offer Issue Reproduction
+  version: '1.0.0'
+  description: Minimal AsyncAPI contract reproducing compilation errors
+
+channels:
+  syncProductOffers:
+    subscribe:
+      operationId: syncProductOffersRequest
+      message:
+        payload:
+          $ref: '#/components/schemas/SyncProductOffersRequest'
+
+components:
+  messages:
+    syncProductOffersRequest:
+      payload:
+        $ref: '#/components/schemas/SyncProductOffersRequest'
+
+  schemas:
+    SyncProductOffersRequest:
+      type: object
+      properties:
+        characteristic:
+          $ref: '#/components/schemas/Characteristic'
+        specificationCharacteristic:
+          $ref: '#/components/schemas/SpecificationCharacteristic'
+        booleanRestriction:
+          $ref: '#/components/schemas/BooleanRestriction'
+
+    # Bug: Enum with 'ARRAY' value - causes List<Object>; in generated enum
+    CharacteristicType:
+      type: string
+      enum:
+        - SCALAR
+        - ARRAY
+
+    CharacteristicValueType:
+      type: string
+      enum:
+        - STRING
+        - LONG
+        - BOOLEAN
+        - DATE
+        - INSTANT
+        - TIME
+        - DECIMAL
+        - DICTIONARY
+
+    # Schema that references enum with ARRAY value
+    Characteristic:
+      type: object
+      properties:
+        name:
+          type: string
+        type:
+          $ref: '#/components/schemas/CharacteristicType'
+        valueType:
+          $ref: '#/components/schemas/CharacteristicValueType'
+
+    # Schema using allOf with the above
+    SpecificationCharacteristic:
+      allOf:
+        - $ref: '#/components/schemas/Characteristic'
+      properties:
+        specificationCharacteristicCode:
+          type: string
+
+    # Bug: Array items with type: boolean causes import common.boolean;
+    BooleanRestriction:
+      type: object
+      properties:
+        possibleValues:
+          type: array
+          items:
+            type: boolean
+        defaultValue:
+          type: boolean

--- a/src/main/java/ru/yojo/codegen/mapper/AbstractMapper.java
+++ b/src/main/java/ru/yojo/codegen/mapper/AbstractMapper.java
@@ -612,8 +612,11 @@ public class AbstractMapper {
                         if (getStringValueIfExistOrElseNull(PACKAGE, items) != null) {
                             fillCollectionWithExistingObject(variableProperties, items);
                         } else {
-                            variableProperties.setItems(items.get(TYPE).toString());
-                            variableProperties.setFormat(items.get(TYPE).toString());
+                            String itemType = items.get(TYPE).toString();
+                            variableProperties.setItems(capitalize(itemType));
+                            variableProperties.setFormat(itemType); // lowercase — let setFormat() handle type/valid
+                            fillCollectionType(variableProperties); // handles types not in setFormat switch (e.g. boolean)
+                            variableProperties.setValid(false);    // simple array items don't need @Valid
                         }
                     }
                 }

--- a/src/main/java/ru/yojo/codegen/mapper/ArrayTypeHandler.java
+++ b/src/main/java/ru/yojo/codegen/mapper/ArrayTypeHandler.java
@@ -1,6 +1,7 @@
 package ru.yojo.codegen.mapper;
 
 import static ru.yojo.codegen.constants.Dictionary.ARRAY;
+import static ru.yojo.codegen.constants.Dictionary.ENUMERATION;
 import static ru.yojo.codegen.constants.Dictionary.TYPE;
 import static ru.yojo.codegen.util.MapperUtil.getStringValueIfExistOrElseNull;
 import static ru.yojo.codegen.util.MapperUtil.uncapitalize;
@@ -27,6 +28,10 @@ public class ArrayTypeHandler implements PropertyTypeHandler {
     @Override
     public boolean canHandle(PropertyResolutionContext ctx) {
         String type = getStringValueIfExistOrElseNull(TYPE, ctx.propertiesMap());
+        // Don't match if this property has an 'enum' field - it's an enum constant, not an array
+        if (getStringValueIfExistOrElseNull(ENUMERATION, ctx.propertiesMap()) != null) {
+            return false;
+        }
         return ARRAY.equals(uncapitalize(ctx.variableProperties().getType())) ||
                (type != null && ARRAY.equalsIgnoreCase(type));
     }

--- a/src/test/java/ru/yojo/codegen/generator/QuickProductOfferSyncTest.java
+++ b/src/test/java/ru/yojo/codegen/generator/QuickProductOfferSyncTest.java
@@ -1,0 +1,111 @@
+package ru.yojo.codegen.generator;
+
+import org.junit.jupiter.api.Test;
+import ru.yojo.codegen.context.SpecificationProperties;
+import ru.yojo.codegen.context.YojoContext;
+import ru.yojo.codegen.domain.lombok.Accessors;
+import ru.yojo.codegen.domain.lombok.LombokProperties;
+
+import javax.tools.*;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Quick test to reproduce compilation error with array-of-boolean items
+ * and enum containing 'ARRAY' value in the contract.
+ */
+class QuickProductOfferSyncTest {
+
+    private static final String OUTPUT_DIR = "build/generated-product-offer-test/";
+
+    @Test
+    void testGenerateAndCompile() throws IOException {
+        Path outputPath = Paths.get(OUTPUT_DIR);
+        if (Files.exists(outputPath)) {
+            try (Stream<Path> walk = Files.walk(outputPath)) {
+                walk.sorted((a, b) -> -a.compareTo(b))
+                        .forEach(p -> {
+                            try { Files.deleteIfExists(p); } catch (IOException ignore) {}
+                        });
+            }
+        }
+
+        SpecificationProperties spec = new SpecificationProperties();
+        spec.setSpecName("prod-offer-issue-contract.yaml");
+        spec.setInputDirectory(".");
+        spec.setOutputDirectory(OUTPUT_DIR);
+        spec.setPackageLocation("com.example.generated");
+
+        YojoContext ctx = new YojoContext();
+        ctx.setSpecificationProperties(Collections.singletonList(spec));
+        ctx.setLombokProperties(new LombokProperties(false, false, new Accessors(false, false, false)));
+
+        YojoGenerator gen = new YojoGenerator();
+        try {
+            gen.generateAll(ctx);
+            System.out.println("=== GENERATION SUCCESSFUL ===");
+        } catch (Exception e) {
+            System.err.println("=== GENERATION FAILED ===");
+            e.printStackTrace();
+            fail("Generation failed: " + e.getMessage());
+        }
+
+        // Collect all generated files
+        List<Path> javaFiles = new ArrayList<>();
+        if (Files.exists(outputPath)) {
+            try (Stream<Path> walk = Files.walk(outputPath)) {
+                javaFiles.addAll(walk.filter(p -> p.toString().endsWith(".java")).toList());
+            }
+        }
+
+        System.out.println("Generated " + javaFiles.size() + " Java files:");
+        for (Path f : javaFiles) {
+            System.out.println("  - " + f);
+        }
+
+        if (javaFiles.isEmpty()) {
+            fail("No Java files were generated");
+        }
+
+        // Try to compile
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+        StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
+        Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromPaths(javaFiles);
+
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, null, null, compilationUnits);
+        boolean compiled = task.call();
+
+        if (!compiled) {
+            StringBuilder sb = new StringBuilder("COMPILATION FAILED:\n");
+            for (Diagnostic<? extends JavaFileObject> d : diagnostics.getDiagnostics()) {
+                sb.append(String.format("[%s] %s:%d:%d: %s%n",
+                        d.getKind(),
+                        d.getSource() != null ? d.getSource().getName() : "unknown",
+                        d.getLineNumber(),
+                        d.getColumnNumber(),
+                        d.getMessage(null)));
+            }
+            fail(sb.toString());
+        }
+
+        assertTrue(compiled, "All generated code must compile without errors");
+
+        // Cleanup
+        try (Stream<Path> walk = Files.walk(outputPath)) {
+            walk.sorted((a, b) -> -a.compareTo(b))
+                    .forEach(p -> {
+                        try { Files.deleteIfExists(p); } catch (IOException ignore) {}
+                    });
+        }
+    }
+}


### PR DESCRIPTION
Fixes #70

## Summary

Two bugs in generated Java code:

### Bug 1: `import boolean;`
`items: {type: boolean}` in `type: array` properties generated `import com.example.generated.common.boolean;` — a reserved Java keyword. Root cause: uncapitalized items type `"boolean"` did not match `JAVA_DEFAULT_TYPES` (contains `"Boolean"`), triggering a spurious import.

### Bug 2: Enum constant ARRAY → `List<Object>;`
An enum value named `ARRAY` (e.g., `enum CharacteristicType { SCALAR, ARRAY }`) was incorrectly matched by `ArrayTypeHandler` as an array type, producing `List<Object>;` instead of the enum constant.

## Changes

1. **`AbstractMapper.java`**: Capitalize items type in `fillArrayProperties()` for correct `JAVA_DEFAULT_TYPES` check; keep format lowercase so `setFormat()` switch continues matching; add `fillCollectionType()` + `setValid(false)` for primitive item types not covered by format switch (e.g., `boolean`).
2. **`ArrayTypeHandler.java`**: Early-return when property has `enum` field — enum constants should never be treated as arrays.

## Testing
- All 154 existing tests pass
- New `QuickProductOfferSyncTest` generates + compiles code end-to-end